### PR TITLE
Made Dark/Light Themes visible on all cards

### DIFF
--- a/Crop Recommendation/templates/index.html
+++ b/Crop Recommendation/templates/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <title>Crop Recommendation</title>
     <link rel="icon" type="image/png" href="/AgriTech/images/logo.png">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
     <link
       rel="stylesheet"
       href="{{ url_for('static', filename='style.css') }}"

--- a/Crop Yield Prediction/crop_yield_app/templates/index.html
+++ b/Crop Yield Prediction/crop_yield_app/templates/index.html
@@ -12,6 +12,7 @@
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
     <link rel="stylesheet" href="../../theme.css" />
     <style>
       * {

--- a/Crop_Planning/static/style.css
+++ b/Crop_Planning/static/style.css
@@ -65,7 +65,7 @@ body {
 }
 
 .navbar-title {
-  color: white;
+  color: var(--text-primary);
   font-size: 1.5rem;
   font-weight: 600;
 }

--- a/Crop_Planning/templates/cropplan.html
+++ b/Crop_Planning/templates/cropplan.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/png" href="/AgriTech/images/logo.png">
     <link rel="stylesheet" href="../static/style.css">
     <link rel="stylesheet" href="../../theme.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   </head>
   <body>
     <div id="canvas-container">

--- a/Crop_Prices_Tracker/templates/crop_price_tracker.html
+++ b/Crop_Prices_Tracker/templates/crop_price_tracker.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/png" href="/AgriTech/images/logo.png">
     <link rel="stylesheet" href="../static/styles.css">
     <link rel="stylesheet" href="../../theme.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   </head>
 
   <body>

--- a/Forum/forum.html
+++ b/Forum/forum.html
@@ -6,6 +6,7 @@
   <link rel="icon" type="image/png" href="/AgriTech/images/logo.png">
   <link rel="stylesheet" href="farmer.css" />
   <link rel="stylesheet" href="../theme.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   <style>
   body {
     font-family: Arial, sans-serif;

--- a/disease.css
+++ b/disease.css
@@ -37,7 +37,7 @@ header {
 .header-content {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   gap: 15px;
   margin-bottom: 20px;
 }
@@ -72,7 +72,7 @@ header > p {
   background: rgba(255, 255, 255, 0.2);
   color: white;
   text-decoration: none;
-  padding: 12px 20px;
+  padding: 6px 10px;
   border-radius: 25px;
   font-size: 14px;
   font-weight: 500;

--- a/disease.html
+++ b/disease.html
@@ -7,22 +7,24 @@
     <link rel="icon" type="image/png" href="/AgriTech/images/logo.png">
     <link rel="stylesheet" href="disease.css">
     <link rel="stylesheet" href="theme.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   </head>
   <body>
     <div class="container">
       <header class="header">
         <div class="header-content">
+          <a href="main.html" class="back-button"> ← Back to Main </a>
           <div>
             <h1>🌱 Plant Disease Detection</h1>
             <p>AI-Powered Plant Health Diagnosis System</p>
           </div>
           <div style="display: flex; gap: 1rem; align-items: center;">
-            <button class="theme-toggle" aria-label="Toggle dark/light mode" style="background: rgba(255, 255, 255, 0.2); border: 1px solid rgba(255, 255, 255, 0.3); color: white;">
+            <button class="theme-toggle" aria-label="Toggle dark/light mode">
               <i class="fas fa-sun sun-icon"></i>
               <i class="fas fa-moon moon-icon"></i>
               <span class="theme-text">Light</span>
             </button>
-            <a href="main.html" class="back-button"> ← Back to Main </a>
+            
           </div>
         </div>
       </header>

--- a/farmer.html
+++ b/farmer.html
@@ -12,6 +12,7 @@
     rel="stylesheet" />
     <link rel="stylesheet" href="farmer.css">
     <link rel="stylesheet" href="theme.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   </head>
   <body>
     <header>
@@ -22,7 +23,7 @@
             Connecting farmers with buyers across India
           </p>
           <div style="display: flex; gap: 1rem; align-items: center;">
-            <button class="theme-toggle" aria-label="Toggle dark/light mode" style="background: rgba(255, 255, 255, 0.2); border: 1px solid rgba(255, 255, 255, 0.3); color: white;">
+            <button class="theme-toggle" aria-label="Toggle dark/light mode">
               <i class="fas fa-sun sun-icon"></i>
               <i class="fas fa-moon moon-icon"></i>
               <span class="theme-text">Light</span>

--- a/organic.html
+++ b/organic.html
@@ -6,6 +6,8 @@
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <title>AgriTech – Organic Farming</title>
     <link rel="stylesheet" href="organic.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
+    
     <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
@@ -29,7 +31,7 @@
           <h1>Welcome to AgriTech</h1>
         </div>
         <div style="display: flex; gap: 1rem; align-items: center;">
-          <button class="theme-toggle" aria-label="Toggle dark/light mode" style="background: rgba(255, 255, 255, 0.2); border: 1px solid rgba(255, 255, 255, 0.3); color: white;">
+          <button class="theme-toggle" aria-label="Toggle dark/light mode">
             <i class="fas fa-sun sun-icon"></i>
             <i class="fas fa-moon moon-icon"></i>
             <span class="theme-text">Light</span>

--- a/theme.css
+++ b/theme.css
@@ -64,7 +64,7 @@ body {
 }
 
 /* Theme Toggle Button */
-.theme-toggle {
+.theme-toggle,.back-button {
   position: relative;
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
@@ -133,6 +133,7 @@ body {
   border-color: var(--border-color);
   color: var(--text-primary);
 }
+.back-button
 
 /* Secondary backgrounds */
 .chat-header,


### PR DESCRIPTION
To improve user experience and ensure theme consistency, dark and light mode icons have been made visible on all cards. This provides a clear indication of the current theme and allows users to quickly recognize theme-related actions across the application interface.
Before:
<img width="1204" height="629" alt="Screenshot 2025-08-31 at 7 44 02 PM" src="https://github.com/user-attachments/assets/7af46df0-97b3-471e-a412-e28cc297faa9" />
After:
<img width="1302" height="629" alt="Screenshot 2025-08-31 at 7 44 17 PM" src="https://github.com/user-attachments/assets/8e161197-e458-4538-91aa-e098d93bae7c" />
<img width="1302" height="629" alt="Screenshot 2025-08-31 at 7 44 21 PM" src="https://github.com/user-attachments/assets/47dd587b-1234-438d-a921-5b2e9e7d2079" />
