### PR TITLE
Add scroll to top button on dashboard page

### DIFF
--- a/main.css
+++ b/main.css
@@ -771,3 +771,35 @@ footer a:hover {
         
     }
 }
+
+    /* Scroll to Top Button */
+    .scroll-to-top {
+      position: fixed;
+      bottom: 2rem;
+      right: 2rem;
+      width: 50px;
+      height: 50px;
+      background: var(--primary-green);
+      color: white;
+      border: none;
+      border-radius: 50%;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 4px 15px var(--shadow-medium);
+      transition: all 0.3s ease;
+      opacity: 0;
+      visibility: hidden;
+      z-index: 1000;
+    }
+
+    .scroll-to-top.visible {
+      opacity: 1;
+      visibility: visible;
+    }
+
+    .scroll-to-top:hover {
+      transform: translateY(-3px);
+      box-shadow: 0 6px 20px var(--shadow-heavy);
+    }

--- a/main.html
+++ b/main.html
@@ -622,6 +622,30 @@
     </footer>
     <script src="main.js"></script>
   <script src="theme.js"></script>
+
+    <button class="scroll-to-top" id="scrollToTop" title="Back to top">
+    <i class="fas fa-arrow-up"></i>
+  </button>
+  <script>
+  // Scroll to top functionality
+    const scrollToTopBtn = document.getElementById("scrollToTop");
+
+    window.addEventListener("scroll", () => {
+      if (window.pageYOffset > 300) {
+        scrollToTopBtn.classList.add("visible");
+      } else {
+        scrollToTopBtn.classList.remove("visible");
+      }
+    });
+
+    scrollToTopBtn.addEventListener("click", () => {
+      window.scrollTo({
+        top: 0,
+        behavior: "smooth",
+      });
+    });
+</script>
+
 <!--   <script src="auth.js"></script> -->
   <script>
         // Check authentication on page load


### PR DESCRIPTION
This PR closes issue #274 

## PR Description:

This PR adds a Scroll to Top button to the Dashboard page to improve user navigation when scrolling through long content.

## What’s Done:

- Button appears after scrolling down

- Matches the dashboard color scheme and styling

- Smooth scroll effect to top when clicked

- Fully responsive (works on both desktop & mobile)

## Before :
<img width="503" height="276" alt="Screenshot 2025-09-08 180501" src="https://github.com/user-attachments/assets/f053f26e-75a2-468b-a472-5fc2390536dc" />

## After 
<img width="512" height="174" alt="Screenshot 2025-09-08 180420" src="https://github.com/user-attachments/assets/1881fa16-943e-47da-9b03-f174c168b802" />

