### PR TITLE
Add Faq in Home Page

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,6 +121,75 @@
     </div>
   </section>
 
+  <section class="faq">
+    <div class="faq-container">
+      <h2 class="faq-title serif">Frequently Asked Questions</h2>
+      <p class="faq-subtitle">Find answers to common questions about our AgriTech platform</p>
+      
+      <div class="faq-grid">
+        <div class="faq-item" role="button" tabindex="0" aria-expanded="false" aria-controls="faq-answer-1">
+          <div class="faq-question">
+            <h3 id="faq-question-1">How does AgriTech connect farmers with buyers?</h3>
+            <i class="fas fa-chevron-down faq-icon" aria-hidden="true"></i>
+          </div>
+          <div class="faq-answer" id="faq-answer-1" aria-labelledby="faq-question-1">
+            <p>Our platform provides a direct marketplace where farmers can list their produce and buyers can browse and purchase directly. We verify all participants and ensure transparent pricing and quality standards.</p>
+          </div>
+        </div>
+
+        <div class="faq-item" role="button" tabindex="0" aria-expanded="false" aria-controls="faq-answer-2">
+          <div class="faq-question">
+            <h3 id="faq-question-2">What equipment rental services are available?</h3>
+            <i class="fas fa-chevron-down faq-icon" aria-hidden="true"></i>
+          </div>
+          <div class="faq-answer" id="faq-answer-2" aria-labelledby="faq-question-2">
+            <p>We offer a wide range of modern agricultural equipment including tractors, harvesters, irrigation systems, and specialized farming tools. All equipment is maintained and operated by certified professionals.</p>
+          </div>
+        </div>
+
+        <div class="faq-item" role="button" tabindex="0" aria-expanded="false" aria-controls="faq-answer-3">
+          <div class="faq-question">
+            <h3 id="faq-question-3">How do you ensure fair pricing for farmers?</h3>
+            <i class="fas fa-chevron-down faq-icon" aria-hidden="true"></i>
+          </div>
+          <div class="faq-answer" id="faq-answer-3" aria-labelledby="faq-question-3">
+            <p>We use real-time market data and transparent pricing algorithms. Farmers can see current market rates and set competitive prices. Our platform eliminates middlemen, ensuring farmers get better profits.</p>
+          </div>
+        </div>
+
+        <div class="faq-item" role="button" tabindex="0" aria-expanded="false" aria-controls="faq-answer-4">
+          <div class="faq-question">
+            <h3 id="faq-question-4">What support do you provide to new users?</h3>
+            <i class="fas fa-chevron-down faq-icon" aria-hidden="true"></i>
+          </div>
+          <div class="faq-answer" id="faq-answer-4" aria-labelledby="faq-question-4">
+            <p>We offer comprehensive onboarding, 24/7 customer support, training materials, and dedicated account managers. Our AI assistant is also available to help with common questions and platform navigation.</p>
+          </div>
+        </div>
+
+        <div class="faq-item" role="button" tabindex="0" aria-expanded="false" aria-controls="faq-answer-5">
+          <div class="faq-question">
+            <h3 id="faq-question-5">Is the platform available in multiple languages?</h3>
+            <i class="fas fa-chevron-down faq-icon" aria-hidden="true"></i>
+          </div>
+          <div class="faq-answer" id="faq-answer-5" aria-labelledby="faq-question-5">
+            <p>Yes, our platform supports multiple Indian languages including Hindi, Telugu, Tamil, Bengali, and more. We're continuously adding support for additional regional languages.</p>
+          </div>
+        </div>
+
+        <div class="faq-item" role="button" tabindex="0" aria-expanded="false" aria-controls="faq-answer-6">
+          <div class="faq-question">
+            <h3 id="faq-question-6">How secure are transactions on AgriTech?</h3>
+            <i class="fas fa-chevron-down faq-icon" aria-hidden="true"></i>
+          </div>
+          <div class="faq-answer" id="faq-answer-6" aria-labelledby="faq-question-6">
+            <p>We use bank-grade encryption and secure payment gateways. All transactions are protected with multiple verification layers, and we offer dispute resolution services for added security.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <section class="cta">
     <div class="cta-content">
       <h3 class="serif">Ready to Transform Agriculture?</h3>
@@ -259,6 +328,86 @@
 
     window.addEventListener("load", () => {
       document.body.style.opacity = "1";
+    });
+
+    // FAQ Accordion functionality
+    document.addEventListener('DOMContentLoaded', function() {
+      const faqItems = document.querySelectorAll('.faq-item');
+      
+      faqItems.forEach(item => {
+        const question = item.querySelector('.faq-question');
+        const answer = item.querySelector('.faq-answer');
+        
+        // Handle click events
+        question.addEventListener('click', () => {
+          toggleFAQ(item);
+        });
+        
+        // Handle keyboard events
+        item.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            toggleFAQ(item);
+          }
+        });
+        
+        // Add focus styling
+        item.addEventListener('focus', () => {
+          item.style.outline = '2px solid var(--primary-green)';
+          item.style.outlineOffset = '2px';
+        });
+        
+        item.addEventListener('blur', () => {
+          item.style.outline = 'none';
+        });
+      });
+      
+      function toggleFAQ(item) {
+        const isActive = item.classList.contains('active');
+        const answer = item.querySelector('.faq-answer');
+        
+        // Close all other FAQ items
+        faqItems.forEach(otherItem => {
+          if (otherItem !== item) {
+            otherItem.classList.remove('active');
+            otherItem.setAttribute('aria-expanded', 'false');
+          }
+        });
+        
+        // Toggle current item
+        if (isActive) {
+          item.classList.remove('active');
+          item.setAttribute('aria-expanded', 'false');
+        } else {
+          item.classList.add('active');
+          item.setAttribute('aria-expanded', 'true');
+          
+          // Smooth scroll into view
+          setTimeout(() => {
+            item.scrollIntoView({
+              behavior: 'smooth',
+              block: 'nearest'
+            });
+          }, 100);
+        }
+      }
+      
+      // Add stagger animation on scroll
+      const faqObserver = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.style.animationPlayState = 'running';
+          }
+        });
+      }, {
+        threshold: 0.1,
+        rootMargin: '0px 0px -50px 0px'
+      });
+      
+      // Observe FAQ items
+      faqItems.forEach(item => {
+        faqObserver.observe(item);
+      });
     });
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -805,3 +805,222 @@
   box-shadow: 0 6px 20px var(--shadow-heavy);
 }
 
+/* FAQ Section */
+.faq {
+  padding: 4rem 2rem;
+  background: var(--bg-secondary);
+  position: relative;
+  overflow: hidden;
+  opacity: 0;
+  animation: fadeIn 1s ease 0.5s forwards;
+}
+
+.faq::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--primary-green), transparent);
+}
+
+.faq-container {
+  max-width: 800px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.faq-title {
+  font-size: 2.5rem;
+  color: var(--text-primary);
+  margin-bottom: 1rem;
+  opacity: 0;
+  transform: translateY(30px);
+  animation: fadeInUp 0.8s ease forwards;
+}
+
+.faq-subtitle {
+  font-size: 1.125rem;
+  color: var(--text-secondary);
+  margin-bottom: 3rem;
+  opacity: 0;
+  transform: translateY(30px);
+  animation: fadeInUp 0.8s ease 0.2s forwards;
+}
+
+.faq-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-align: left;
+}
+
+.faq-item {
+  background: var(--bg-primary);
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  overflow: hidden;
+  transition: all 0.3s ease;
+  opacity: 0;
+  transform: translateY(30px);
+  animation: fadeInUp 0.6s ease forwards;
+  cursor: pointer;
+}
+
+.faq-item:focus {
+  outline: 2px solid var(--primary-green);
+  outline-offset: 2px;
+}
+
+.faq-item:focus-visible {
+  outline: 2px solid var(--primary-green);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(22, 163, 74, 0.1);
+}
+
+.faq-item:nth-child(1) { animation-delay: 0.1s; }
+.faq-item:nth-child(2) { animation-delay: 0.2s; }
+.faq-item:nth-child(3) { animation-delay: 0.3s; }
+.faq-item:nth-child(4) { animation-delay: 0.4s; }
+.faq-item:nth-child(5) { animation-delay: 0.5s; }
+.faq-item:nth-child(6) { animation-delay: 0.6s; }
+
+.faq-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px var(--shadow-medium);
+  border-color: var(--primary-green);
+}
+
+.faq-question {
+  padding: 1.5rem;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: all 0.3s ease;
+  position: relative;
+}
+
+.faq-question::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 1.5rem;
+  right: 1.5rem;
+  height: 1px;
+  background: var(--border-color);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.faq-item.active .faq-question::after {
+  opacity: 1;
+}
+
+.faq-question h3 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  padding-right: 1rem;
+  transition: color 0.3s ease;
+}
+
+.faq-item:hover .faq-question h3 {
+  color: var(--primary-green);
+}
+
+.faq-icon {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  transition: all 0.3s ease;
+  flex-shrink: 0;
+}
+
+.faq-item:hover .faq-icon {
+  color: var(--primary-green);
+}
+
+.faq-item.active .faq-icon {
+  transform: rotate(180deg);
+  color: var(--primary-green);
+}
+
+.faq-answer {
+  max-height: 0;
+  overflow: hidden;
+  transition: all 0.4s ease;
+  background: var(--bg-tertiary);
+}
+
+.faq-item.active .faq-answer {
+  max-height: 200px;
+  padding: 0 1.5rem 1.5rem 1.5rem;
+}
+
+.faq-answer p {
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 0;
+  padding-top: 1rem;
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: all 0.3s ease 0.1s;
+}
+
+.faq-item.active .faq-answer p {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* FAQ Animations */
+@keyframes fadeInUp {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes pulse {
+  0%, 100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+}
+
+/* FAQ Responsive Design */
+@media (max-width: 768px) {
+  .faq {
+    padding: 3rem 1rem;
+  }
+  
+  .faq-title {
+    font-size: 2rem;
+  }
+  
+  .faq-subtitle {
+    font-size: 1rem;
+    margin-bottom: 2rem;
+  }
+  
+  .faq-question {
+    padding: 1.25rem;
+  }
+  
+  .faq-question h3 {
+    font-size: 1rem;
+  }
+  
+  .faq-item.active .faq-answer {
+    padding: 0 1.25rem 1.25rem 1.25rem;
+  }
+  
+  .faq-question::after {
+    left: 1.25rem;
+    right: 1.25rem;
+  }
+}
+


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #321

## Rationale for this change

The AgriTech website currently lacks a FAQ section on the landing page. Since most users first check the Home Page, navigating to a separate FAQ page can be inconvenient. Adding the FAQ here makes the site more user-friendly and engaging.

## What changes are included in this PR?

- Added a FAQ section directly to the Home Page.  
- Implemented accordion-style expand/collapse layout with smooth animations.  
- Applied dark mode–compatible styling consistent with AgriTech branding.  
- Included sample FAQ questions and answers relevant to users.  

## Are these changes tested?

Yes, tested manually to ensure:  
- Accordion expand/collapse works smoothly.  
- Animations run without breaking layout.  
- Dark and light mode styles are applied properly.  

## Are there any user-facing changes?

Yes, users will now see a FAQ section directly on the Home Page with an interactive design, improving usability and overall experience.  


<img width="1350" height="621" alt="image" src="https://github.com/user-attachments/assets/fa68d4db-58ef-4d36-b0d2-5e149365b756" />

