### PR TITLE
removed the repeated regexes from the dangerous_patterns list in sanitize_sql_input function

### DIFF
--- a/security_utils.py
+++ b/security_utils.py
@@ -176,10 +176,6 @@ def sanitize_sql_input(value):
         r'(\b(and|or)\b\s+\d+\s*=\s*\d+)',
         r'(\b(and|or)\b\s+\'\w+\'\s*=\s*\'\w+\')',
         r'(\b(and|or)\b\s+\w+\s*=\s*\w+)',
-        r'(\b(union|select|insert|update|delete|drop|create|alter|exec|execute)\b)',
-        r'(\b(and|or)\b\s+\d+\s*=\s*\d+)',
-        r'(\b(and|or)\b\s+\'\w+\'\s*=\s*\'\w+\')',
-        r'(\b(and|or)\b\s+\w+\s*=\s*\w+)',
     ]
     
     cleaned = value


### PR DESCRIPTION
removed the repeated regexes from the dangerous_patterns list in sanitize_sql_input function. This makes the function more efficient and easier to maintain, without affecting its security logic. No other part of the file was changed for this bug.
