### PR TITLE
Fix: updated theme toggle icons to reflect opposite mode in contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -220,10 +220,10 @@
       const icon = themeToggle.querySelector('i');
 
       if (body.classList.contains('dark-mode')) {
-        icon.className = 'fas fa-moon';
+        icon.className = 'fas fa-sun';
         localStorage.setItem('theme', 'dark');
       } else {
-        icon.className = 'fas fa-sun';
+        icon.className = 'fas fa-moon';
         localStorage.setItem('theme', 'light');
       }
     });
@@ -232,7 +232,7 @@
     const savedTheme = localStorage.getItem('theme');
     if (savedTheme === 'dark') {
       body.classList.add('dark-mode');
-      themeToggle.querySelector('i').className = 'fas fa-moon';
+      themeToggle.querySelector('i').className = 'fas fa-sun';
     }
 
     // Form submission


### PR DESCRIPTION
## Which issue does this PR close?


- Closes #389 

## Rationale for this change

Made theme icons to toggle correctly, by displaying moon in light mode and sun in dark mode.

## Are these changes tested?

Changes are tested locally.

## Image after fix
<img width="1366" height="768" alt="Screenshot (540)" src="https://github.com/user-attachments/assets/2a456544-cb2d-4eb0-bd55-861c1db935f8" />
