### PR TITLE
fix(#340): prevent non-plant images from being analyzed by adding MobileNet-based plant validation before disease prediction

### DIFF
--- a/disease.html
+++ b/disease.html
@@ -378,6 +378,8 @@
       </div>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/mobilenet"></script>
     <script src="disease.js"></script>
     <script src="theme.js"></script>
       <style>


### PR DESCRIPTION
## **PR Summary**
Implements image validation using MobileNet to ensure only plant images are analyzed on the Disease Prediction page (#340)

---

## **Description**
This PR fixes a major issue on the Disease Prediction page where the system would accept any uploaded image (including non-plant images like bottles or papers) and still display a plant disease prediction.  

With this update, the application now validates whether the uploaded image is actually a **plant image** using the **TensorFlow.js MobileNet model** before running any disease prediction logic.  

If the uploaded image does not resemble a plant, the system displays a clear warning message — *“Please upload a valid plant image”* — instead of producing an incorrect result.

---

## **Changes Included**

### **Disease Prediction Page**
- Integrated **TensorFlow.js MobileNet model** for image validation.  
- Added a **pre-check** before disease prediction to confirm if the uploaded image contains a plant, leaf, flower, or crop.  
- Ensured **fallback** if the MobileNet model is still loading.

---

## **Expected Behavior**
- Uploading a **valid plant image** → proceeds with analysis and displays disease results.  
- Uploading a **non-plant image** (e.g., bottle, shoe, page) → shows a warning card:  
  > ⚠️ Invalid Image  
  > Please upload a valid plant image.  
- Prevents false or misleading predictions.  

---

## **Related Issue**
Closes **#340**

---

## **Screenshots**

### **Before (Old Behavior)**
<img width="1470" height="956" alt="Screenshot 2025-10-24 at 4 15 50 PM" src="https://github.com/user-attachments/assets/e2137dd4-e994-4c94-a1a9-97ff288f10e3" />


### **After (Fixed Behavior)**
<img width="1470" height="956" alt="Screenshot 2025-10-24 at 4 16 10 PM" src="https://github.com/user-attachments/assets/1830b28e-c45c-4731-b719-43b2f1baa177" />
