### PR TITLE
Fix heading visibility issue in light mode on Smart Crop Monitoring page

### DIFF
--- a/crop.html
+++ b/crop.html
@@ -126,7 +126,7 @@
         }
 
         .header {
-            background: rgba(30, 41, 59, 0.95);
+            background: var(--bg-secondary);
             backdrop-filter: blur(10px);
             border: 1px solid var(--border-color);
             border-radius: 15px;
@@ -212,7 +212,7 @@
         }
 
         .feature-card {
-            background: rgba(30, 41, 59, 0.95);
+            background: var(--bg-secondary);
             backdrop-filter: blur(10px);
             border: 1px solid var(--border-color);
             border-radius: 15px;
@@ -282,7 +282,8 @@
         }
 
         .monitoring-dashboard {
-            background: rgba(30, 41, 59, 0.95);
+
+            background: var(--bg-secondary);
             backdrop-filter: blur(10px);
             border: 1px solid var(--border-color);
             border-radius: 15px;
@@ -839,6 +840,10 @@
             0% { transform: rotate(0deg); }
             100% { transform: rotate(360deg); }
         }
+        [data-theme="dark"] .header::before {
+    opacity: 0.3;
+        }
+
     </style>
 </head>
 <body data-theme="dark">
@@ -890,6 +895,7 @@
             </button>
             <button class="control-btn" onclick="exportData()">
                 <i class="fas fa-download"></i> Export
+                
             </button>
             <button class="control-btn" onclick="refreshData()">
                 <i class="fas fa-sync-alt"></i> Refresh


### PR DESCRIPTION
This PR fixes a UI issue on the Smart Crop Monitoring page where dark-theme styles were affecting the light mode layout, causing headings to appear unclear or invisible.

Changes made:
- Replaced hardcoded dark background colors with theme variables
- Ensured proper contrast for headings and card titles in light mode
- Preserved existing dark mode behavior

This improves readability and visual consistency without altering the page layout.
fixes #451 
