### PR TITLE
Fix chart tabs overflow and alignment on mobile

### DIFF
--- a/crop.html
+++ b/crop.html
@@ -803,6 +803,15 @@
             .control-btn {
                 flex-shrink: 0;
             }
+            .chart-tabs{
+                flex-wrap: wrap;
+                justify-content: center;  
+                gap: 6px; 
+            }
+            .chart-tab{
+                padding: 6px 10px;  
+                white-space: nowrap;      
+            }
         }
 
         .loading-overlay {


### PR DESCRIPTION
- Closes #468

## Rationale for this change
The sensor chart tabs were overflowing and breaking the layout on mobile screens.
This change improves mobile responsiveness and ensures the chart tabs stay within
the container with proper alignment.

## What changes are included in this PR?
- Enabled wrapping for sensor chart tabs on mobile view
- Improved alignment and spacing to prevent layout break
- Ensured chart tab text stays on a single line for better UI clarity

### Screenshots
-Before Fix (Mobile View)
<img width="404" height="648" alt="Before Fix" src="https://github.com/user-attachments/assets/66f1562b-e8a0-4106-80bc-628d2d927206" />

-After Fix (Mobile View)
<img width="400" height="656" alt="After Fix" src="https://github.com/user-attachments/assets/492d8f9a-02b3-4fea-8fd5-85528e893fa6" />
