### PR TITLE
Fix footer Email Us and Call Us links (mailto & tel)

### DIFF
--- a/index.html
+++ b/index.html
@@ -780,8 +780,16 @@
       <div class="footer-links">
         <h4 class="serif">Contact</h4>
         <ul>
-          <li><a href="#"><i class="fas fa-envelope"></i> Email Us</a></li>
-          <li><a href="#"><i class="fas fa-phone"></i> Call Us</a></li>
+          <li>
+            <a href="mailto:contact@agritech.com">
+              <i class="fas fa-envelope"></i> Email Us
+            </a>
+          </li>
+          <li>
+            <a href="tel:+910000000000">
+              <i class="fas fa-phone"></i> Call Us
+            </a>
+          </li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
### What was fixed
- Fixed the footer Email Us link so it opens the default email client using `mailto:`
- Fixed the Call Us link using `tel:` since it had the same issue and was redirecting to the homepage

### Notes
- Placeholder email address and phone number are used as suggested by the maintainer.

Closes #467
