### PR TITLE
Security: Fix unauthorized room creation in Socket.IO

### DIFF
--- a/Community/app.py
+++ b/Community/app.py
@@ -40,15 +40,23 @@ def delete_community():
 
 @socketio.on('join')
 def on_join(data):
-    username = data['username']
-    room = data['room']
+    username = data.get('username')
+    room = data.get('room')
+    
+    if not username or not room:
+        emit('error', {'msg': 'Username and Room are required.'})
+        return
+
     if room not in communities:
-        communities[room] = set()
+        emit('error', {'msg': 'Room does not exist.'})
+        return 
+
     join_room(room)
     communities[room].add(username)
+    
     send({'msg': f'{username} joined {room}'}, room=room)
     emit('user_list', list(communities[room]), room=room)
-
+    
 @socketio.on('leave')
 def on_leave(data):
     username = data['username']


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #444

## Rationale for this change

This PR addresses a **critical security vulnerability** (Insecure Direct Object Reference / Improper Authorization) in the `Community/app.py` Socket.IO handler.

Currently, the `on_join` event automatically creates a new room if the requested room name does not exist in the `communities` dictionary. This allows malicious actors to spam the server with unlimited random room names, potentially leading to **Resource Exhaustion (DoS)** or the creation of unauthorized communication channels.

This change shifts the logic from "implicit creation" to "explicit validation."

## What changes are included in this PR?

- **Security Fix in `on_join`:** Added a strict conditional check to verify if a `room` exists in the `communities` dictionary before allowing a user to join.
- **Error Handling:** If a user attempts to join a non-existent room, the server now emits an `error` event with the message "Room does not exist" and aborts the operation.
- **Safe Data Access:** Updated `data['username']` and `data['room']` to `data.get(...)` in the join handler to prevent `KeyError` crashes on malformed packets.
- **Admin Management:** Explicit room creation is now handled solely via the secure `/add_community` API endpoint, restricting room creation to administrators only.

## Are these changes tested?

Yes, these changes have been manually tested locally.

**Test Scenarios:**
1.  **Unauthorized Join:** Attempted to emit a `join` event for a non-existent room (`"fake_room"`).
    * *Result:* Server did **not** create the room. Client received `{'msg': 'Room does not exist.'}`.
2.  **Authorized Join:** Created a room via the admin API and attempted to join.
    * *Result:* Success. User added to the room and user list updated.
3.  **Malformed Data:** Sent a join request with missing keys.
    * *Result:* Server handled it gracefully without crashing and returned an error message.

## Are there any user-facing changes?

- **Yes.** Users can no longer create arbitrary chat rooms by simply typing a new name. They are restricted to joining the official communities listed by the platform.
- The frontend client may need to listen for the new `'error'` event on the socket to display feedback if a user tries to join an invalid room (though under normal UI operation, this should not happen).