### PR TITLE
Fix settings panel styles in light mode

### DIFF
--- a/crop.html
+++ b/crop.html
@@ -660,6 +660,21 @@
             right: 0;
         }
 
+        [data-theme="light"] .settings-panel {
+            background: rgba(248, 250, 252, 0.98);
+            color: var(--text-primary);
+        }
+
+        [data-theme="light"] .settings-panel h3,
+        [data-theme="light"] .settings-panel h4 {
+            color: var(--text-primary);
+        }
+
+        [data-theme="light"] .settings-panel .setting-item span {
+            color: var(--text-secondary);
+        }
+
+
         .settings-header {
             display: flex;
             justify-content: space-between;
@@ -668,6 +683,11 @@
             padding-bottom: 20px;
             border-bottom: 1px solid var(--border-color);
         }
+
+        .settings-header button {
+            cursor: pointer;
+        }
+
 
         .settings-group {
             margin-bottom: 25px;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #568 

## Rationale for this change

- This change improves the readability and usability of the dashboard settings panel in light theme by fixing low-contrast text and non-intuitive cursor behavior on the close button.
- Previously, the settings panel always used a dark background color and default cursor, which caused labels to appear faint and the close icon to feel non-clickable when light mode was enabled

## What changes are included in this PR?

- Make the settings panel background and text colors respond to the active theme using existing CSS variables for light mode.
- Update the settings close button styles so the cursor changes to pointer when hovering over the cross icon.
- Ensure related elements in the panel (section headings, labels, and dividers) remain readable in both dark and light themes.


<img width="1894" height="844" alt="image" src="https://github.com/user-attachments/assets/d4c92e71-fa04-4362-bcb0-3f75c8a1af16" />

## Are these changes tested?

- Manually tested by toggling between dark and light themes and verifying the settings panel remains readable in both modes.
- Manually tested that the close button shows the pointer cursor on hover and still correctly closes the settings panel.


## Are there any user-facing changes?

- Yes: users on light theme now see clearly readable settings labels and headers in the settings panel.
- Yes: the close icon in the settings panel now shows a pointer cursor, making it clearer that it is clickable.
