### PR TITLE
feat: add count-up animation to impact section

### DIFF
--- a/financial-support.html
+++ b/financial-support.html
@@ -756,6 +756,44 @@
   </style>
 </head>
 
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+    const counters = document.querySelectorAll('.stat-number');
+    const speed = 200; // The lower the slower
+
+    const animateCounters = (entries, observer) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                const counter = entry.target;
+                const updateCount = () => {
+                    const target = +counter.getAttribute('data-target');
+                    const count = +counter.innerText;
+                    
+                    const inc = target / speed;
+
+                    if (count < target) {
+                        counter.innerText = Math.ceil(count + inc);
+                        setTimeout(updateCount, 20);
+                    } else {
+                        counter.innerText = target;
+                    }
+                };
+
+                updateCount();
+                observer.unobserve(counter); 
+            }
+        });
+    };
+
+    const sectionObserver = new IntersectionObserver(animateCounters, {
+        threshold: 0.7 
+    });
+
+    counters.forEach(counter => {
+        sectionObserver.observe(counter);
+    });
+});
+</script>
 <body>
   <nav class="navbar">
     <div class="navbar-content">


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #751
## Rationale for this change
The "Our Impact" section contained static numbers. Adding a count-up animation makes the page more dynamic and engaging for users, as requested in the issue.
## What changes are included in this PR?
- Added a `script` block to the `financial-support.html` file.
- Implemented `IntersectionObserver` to detect when the statistics section scrolls into view.
- Added logic to animate numbers from 0 to their `data-target` value.
## Are these changes tested?
Yes. I manually tested the page:
1. Loaded the page and scrolled down to the "Financial Support" section.
2. Verified that the numbers start at 0 and count up smoothly to the final values (500, 25000, etc.).
## Are there any user-facing changes?
Yes, the statistics in the "Our Impact" section now animate visually instead of appearing instantly.