### PR TITLE
Fix dark mode toggle and  alignment without affecting schemes logic

### DIFF
--- a/scheme.html
+++ b/scheme.html
@@ -29,10 +29,14 @@ header{
   color:#fff;
   padding:24px 30px;
   display:flex;
-  justify-content:space-between;
   align-items:center;
+  gap:20px;
 }
-header h1{font-size:26px;font-weight:800}
+header h1{
+  font-size:26px;
+  font-weight:800;
+  flex:1; /* pushes right items safely */
+}
 header a{
   background:#fff;
   color:var(--primary);
@@ -165,6 +169,77 @@ button{
   .form-card{padding:30px}
   .form-card h2{font-size:26px}
 }
+/* ========= PREMIUM DARK MODE ========= */
+body.dark{
+  --bg:#0b1220;
+  --card:#111827;
+  --text:#e5e7eb;
+  --primary:#22c55e;
+  --secondary:#16a34a;
+  --shadow:0 20px 50px rgba(0,0,0,0.7);
+}
+
+/* text fix */
+body.dark,
+body.dark p,
+body.dark label{
+  color:var(--text);
+}
+
+/* inputs */
+body.dark select,
+body.dark input{
+  background:#020617;
+  color:#e5e7eb;
+  border:1px solid #334155;
+}
+
+/* cards */
+body.dark .form-card,
+body.dark .scheme,
+body.dark .modal-content{
+  background:var(--card);
+}
+
+/* eligibility visibility */
+body.dark .eligible{color:#4ade80}
+body.dark .not-eligible{color:#f87171}
+body.dark .deadline{color:#fb7185}
+
+/* header button */
+.dark-toggle{
+  width:54px;
+  height:30px;
+  border-radius:30px;
+  background:#e5e7eb;
+  position:relative;
+  cursor:pointer;
+  transition:0.3s;
+}
+.dark-toggle::before{
+  content:"☀️";
+  position:absolute;
+  left:5px;
+  top:3px;
+  transition:0.3s;
+}
+body.dark .dark-toggle{
+  background:#020617;
+}
+body.dark .dark-toggle::before{
+  content:"🌙";
+  left:28px;
+}
+
+/* apply button */
+body.dark .apply{background:#2563eb}
+body.dark .apply.disabled{background:#475569}
+
+/* modal overlay */
+body.dark .modal{
+  background:rgba(2,6,23,0.85);
+}
+
 </style>
 </head>
 
@@ -172,6 +247,7 @@ button{
 
 <header>
   <h1>📜 Govt Schemes & Subsidy Tracker</h1>
+  <div class="dark-toggle" onclick="toggleDark()"></div>
   <a href="index.html">⬅ Back to Home</a>
 </header>
 
@@ -335,6 +411,19 @@ function showMsg(msg){
 }
 function closeModal(){
   document.getElementById("modal").style.display="none";
+}
+</script>
+<script>
+function toggleDark(){
+  document.body.classList.toggle("dark");
+  localStorage.setItem(
+    "darkMode",
+    document.body.classList.contains("dark")
+  );
+}
+
+if(localStorage.getItem("darkMode")==="true"){
+  document.body.classList.add("dark");
 }
 </script>
 


### PR DESCRIPTION
### What’s fixed
- Added dark mode toggle without modifying existing scheme logic
- Fixed header layout to prevent overlap with “Back to Home” button
- Ensured responsive alignment across screen sizes

### What’s NOT changed
- Scheme eligibility rules
- Schemes data array
- Reminder, modal, and apply logic

### Screenshots
- Light mode ✅
- Dark mode ✅

<img width="1913" height="928" alt="image" src="https://github.com/user-attachments/assets/43d1902e-f635-4673-82b9-7e2766bf00e7" />
<img width="1890" height="916" alt="image" src="https://github.com/user-attachments/assets/387c34bb-47db-4aec-b12b-e5afcf0f2224" />

This PR #763 closes issue #749