### PR TITLE
[ENHANCEMENT] Calendar Button Color Is Too Light #526

### DIFF
--- a/main.css
+++ b/main.css
@@ -316,7 +316,7 @@ header h2 {
 
 .calendar-button {
   background: linear-gradient(135deg, #a4e857ff, #9ccc65);
-  color: white;
+  color: #3d3c3c;
 }
 
 .calendar-button:hover {


### PR DESCRIPTION
Before:- 

<img width="247" height="108" alt="calendar  button" src="https://github.com/user-attachments/assets/7fcce3c8-83a3-41bb-b339-461413ae6cd0" />

Now:- 

<img width="299" height="141" alt="Screenshot 2026-01-12 203824" src="https://github.com/user-attachments/assets/8e4381dc-8f25-4718-a3c5-8f6132bbfb41" />


issue #526 solved ✅