### PR TITLE
Add accessible scroll-to-top button with FAB spacing

### DIFF
--- a/plantation.css
+++ b/plantation.css
@@ -257,3 +257,41 @@ footer p span {
     display: none;
   }
 }
+
+/* Scroll To Top Button */
+#scrollTopBtn {
+  position: fixed;
+  bottom: 30px;           /* below chatbot (chat is at 100px) */
+  right: 30px;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  border: none;
+  outline: none;
+  background-color: #2ecc71;
+  color: #fff;
+  font-size: 20px;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(0,0,0,0.25);
+  display: none;          /* hidden by default */
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;          /* slightly below chatbot (1100) */
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+/* Show state (optional if you want class-based toggle) */
+#scrollTopBtn.show {
+  display: flex;
+}
+
+#scrollTopBtn:hover {
+  transform: translateY(-4px) scale(1.05);
+  box-shadow: 0 8px 22px rgba(0,0,0,0.35);
+  background-color: #27ae60;
+}
+
+/* Dark mode adjustment */
+[data-theme="dark"] #scrollTopBtn {
+  background-color: #2e7d32;
+}

--- a/plantation.html
+++ b/plantation.html
@@ -874,6 +874,12 @@
         Future 🌾
       </p>
     </footer>
+
+    <!-- Scroll To Top Button -->
+<button id="scrollTopBtn" aria-label="Back to top">
+  <i class="fas fa-arrow-up"></i>
+</button>
+
 <!-- Floating Chatbot Button -->
 <a href="chat.html" id="chatbotBtn" title="Chat with us" aria-label="AI Assistant">
   <i class="fas fa-robot"></i>

--- a/plantation.js
+++ b/plantation.js
@@ -38,3 +38,30 @@ window.addEventListener("scroll", () => {
     }
   });
 });
+
+// Scroll to Top Button Logic
+const scrollTopBtn = document.getElementById('scrollTopBtn');
+const scrollThreshold = 250; // px
+
+const toggleScrollTopBtn = () => {
+  const scrollY = window.scrollY || document.documentElement.scrollTop;
+  if (scrollY > scrollThreshold) {
+    scrollTopBtn.classList.add('show');
+  } else {
+    scrollTopBtn.classList.remove('show');
+  }
+};
+
+const scrollToTop = () => {
+  window.scrollTo({
+    top: 0,
+    behavior: 'smooth'
+  });
+  // Optional: move focus to header for accessibility
+  const header = document.querySelector('header');
+  if (header) header.setAttribute('tabindex', '-1');
+  if (header) header.focus();
+};
+
+window.addEventListener('scroll', toggleScrollTopBtn, { passive: true });
+scrollTopBtn.addEventListener('click', scrollToTop);


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #775 

## Rationale for this change

- Long content pages currently require users to manually scroll all the way back to the top, which is tedious on smaller screens and hurts navigation efficiency.
- Adding an accessible scroll-to-top button reduces interaction cost, improves usability on mobile, and aligns with common UX patterns for long, scrollable documents.

## What changes are included in this PR?

- Added a fixed-position scroll-to-top button that appears after the user scrolls beyond a threshold.
- Implemented smooth scrolling behavior and basic focus management so that activating the button returns users to the top/header region.
- Updated styles to position the button above the footer, avoid overlap with the floating chatbot button, and support both light and dark themes.


<img width="1912" height="838" alt="image" src="https://github.com/user-attachments/assets/e3bf0c04-2ff1-4f34-9f68-28869653f41e" />

## Are these changes tested?

- Manually tested scrolling behavior on desktop and mobile viewports to ensure the button appears/disappears at the expected scroll depth and scrolls to the top smoothly.
- Verified keyboard accessibility (tab focus and activation via Enter/Space) and checked that the button does not obscure existing floating UI (chatbot FAB).


## Are there any user-facing changes?

- Users will now see a circular scroll-to-top button on long pages once they scroll down, providing a quick way to return to the top.
- The interaction is additive and non-breaking; it enhances navigation without altering existing content flow or main interactions on the page.

