### PR TITLE
fix: replace hardcoded copyright year with dynamic JavaScript update

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -313,7 +313,7 @@ connect-src 'self' http://localhost:3000;
           </ul>
         </div>
       </div>
-      <div class="footer-bottom">© 2025 AgriTech • Made for farmers</div>
+      <div class="footer-bottom">© <span id="current-year">2026</span> AgriTech • Made for farmers</div>
     </footer>
   </body>
 </html>

--- a/chat.js
+++ b/chat.js
@@ -1,6 +1,12 @@
 const USE_AI_FALLBACK = true;
 
 document.addEventListener('DOMContentLoaded', () => {
+  // --- BUG FIX: DYNAMIC COPYRIGHT YEAR ---
+  const yearElement = document.getElementById('current-year');
+  if (yearElement) {
+    yearElement.textContent = new Date().getFullYear();
+  }
+
   const chatWindow = document.getElementById('chat-window');
   const chatForm = document.getElementById('chat-form');
   const chatInput = document.getElementById('chat-input');


### PR DESCRIPTION
closes #811 

### **Description**
This PR resolves a bug where the copyright year in the footer was hardcoded to 2025. Since the current year is 2026, the footer appeared outdated.

Key Technical Changes:

HTML Refactor: Added a unique id="current-year" to the copyright span in chat.html to allow for DOM manipulation.

JavaScript Implementation: Integrated a script in chat.js that uses new Date().getFullYear() to dynamically fetch and display the correct year upon page load.

Maintainability: This change prevents the need for manual annual updates and ensures the platform maintains professional standards and legal accuracy.

Impact:

Automatically displays the correct year (2026) across the chat interface.

Improves project professionalism by ensuring metadata is current.



BEFORE:
<img width="811" height="177" alt="image" src="https://github.com/user-attachments/assets/6d5761fe-8792-47aa-98ad-0cc2c09fa984" />


AFTER:
<img width="1316" height="284" alt="image" src="https://github.com/user-attachments/assets/9950588f-87a7-4a62-aa40-27de7a2babb3" />
