### PR TITLE
Language selector behaviour for smart loan guide has been clarified #744

### DIFF
--- a/main.css
+++ b/main.css
@@ -1672,3 +1672,22 @@ nav a {
 .services-mega-menu::-webkit-scrollbar-thumb:hover {
   background: #388e3c;
 }
+
+/* Language helper note (Smart Loan Guide) */
+.language-note {
+  display: block;
+  margin-top: 8px;
+  padding: 6px 10px;
+  background: #f1f8e9;
+  border-left: 3px solid #4caf50;
+  color: #2e7d32;
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+/* Dark mode support */
+[data-theme="dark"] .language-note {
+  background: #1f2d1f;
+  border-left-color: #81c784;
+  color: #c8e6c9;
+}

--- a/main.html
+++ b/main.html
@@ -874,6 +874,11 @@
               <option value="en">English</option>
               <option value="hi">हिन्दी</option>
             </select>
+            <small class="language-note">
+              Language change applies only to Smart Loan Guide
+            </small>
+
+
           </div>
           
         </section>


### PR DESCRIPTION
## Which issue does this PR close?
Clarified the behavior of the language selector for the Smart Loan Guide.

- Closes #744 

## Rationale for this change

Users may assume that the language selector affects the entire dashboard.  
However, it currently applies only to the Smart Loan Guide page, which was not clearly communicated in the UI.

This clarification improves usability and prevents confusion.
## What changes are included in this PR?

- Added a clear helper note indicating that the language selector applies only to the Smart Loan Guide
- Improved the visibility of the note so that it is noticeable in both light and dark modes
- Ensured the message remains accessible and readable across themes

in dark mode
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/59d70c78-4a9a-4992-846b-7971663dd528" />

in light mode
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a26d3bcd-699e-4093-9f25-5e047c2e8f4d" />


## Are these changes tested?

Manual testing was performed:
- Verified correct display in both light and dark themes
- Confirmed no functional behavior was altered
- Ensured navigation to the Smart Loan Guide still passes the selected language correctly

No automated tests were added as this is a UI text clarification.

## Are there any user-facing changes?

Yes.
- Users now see a clear informational note explaining the scope of the language selector, improving clarity and user experience.


