### PR TITLE
Fixed read more modal not opening for last 2 posts

### DIFF
--- a/blog.js
+++ b/blog.js
@@ -57,7 +57,7 @@
         }
 
        // Sample blog data - UPDATED with full content for "Read More" functionality
-const blogPosts = [
+let blogPosts = [
     {
         id: 'sustainable-farming-2025',
         title: "Sustainable Farming Practices for 2025",
@@ -416,8 +416,13 @@ const blogPosts = [
         }
 
         // Open modal
+        blogPosts = blogPosts.map(post => ({
+        ...post,
+        id: String(post.id)
+        }));
+
         function openModal(postId) {
-            const post = blogPosts.find(p => p.id === postId);
+            const post = blogPosts.find(p => (p.id) === (postId));
             if (!post) return;
 
             currentModalPostId = postId;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
🔍 Root Cause

--There was a data type mismatch in the blogPosts array:

--Most post IDs were strings

--The last two post IDs were numbers

--Because strict equality (===) was used while finding the post, the modal failed to load for those entries.

✅ Solution

--Normalized all blogPosts.id values to strings

--Ensured consistent ID comparison across the modal logic

- Closes #703 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
--Normalized all blogPosts.id values to strings to ensure consistent data types

--Fixed the Read More modal not opening for the last two blog cards

--Prevented silent failures caused by strict equality checks (===)

--Improved reliability of modal post lookup logic

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
--Yes. The changes were manually tested in the browser.

Testing performed:

--Clicked the Read More button on all blog cards, including the last two

--Verified that the modal opens correctly and displays the expected content

--Confirmed existing blog cards continue to work as before

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes.

--The Read More modal now opens correctly for all blog cards, including the last two posts

--Users can consistently view full blog content without any broken interactions

--No documentation updates are required, as this change fixes existing behavior rather than introducing new functionality.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
##Screenshots

https://github.com/user-attachments/assets/34995525-10f3-4fcb-9ae9-88deaee71fff


