### PR TITLE
Feat: Add Country-Wise Filter to Crop Calendar

### DIFF
--- a/cropCalendar.css
+++ b/cropCalendar.css
@@ -78,17 +78,26 @@ header h1 {
   background: rgba(255, 255, 255, 0.25);
 }
 
-/* Crop filter */
+/* Filter Styles */
 .filter-container {
   margin: 1.5rem;
   text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
 }
 
-#cropSelect {
+/* Shared styles for both dropdowns */
+#cropSelect, #countrySelect {
   padding: 0.5rem 1rem;
   border: 1px solid #ccc;
   border-radius: 6px;
   font-size: 1rem;
+  background-color: var(--surface-color, #ffffff);
+  color: var(--text-color, #333333);
+  min-width: 150px;
 }
 
 .legend {
@@ -210,6 +219,14 @@ header h1 {
 .calendar-loading {
   text-align: center;
   padding: 2rem;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  grid-column: 1 / -1;
+  min-height: 200px;
+  box-sizing: border-box;
 }
 
 .loading-spinner {
@@ -374,6 +391,17 @@ header h1 {
   .legend-item {
     font-size: 0.85rem;
   }
+  
+  .calendar-loading {
+    padding: 1rem;
+    min-height: 150px;
+  }
+  
+  .calendar.loading {
+    min-width: auto !important;
+    grid-template-columns: 1fr;
+    padding: 1rem;
+  }
 }
 
 @media (max-width: 375px) {
@@ -415,33 +443,5 @@ header h1 {
 
   .legend-item {
     font-size: 0.8rem;
-  }
-}
-
-/* Enhanced loading state for better visibility */
-.calendar-loading {
-  text-align: center;
-  padding: 2rem;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  grid-column: 1 / -1;
-  min-height: 200px;
-  box-sizing: border-box;
-}
-
-@media (max-width: 600px) {
-  .calendar-loading {
-    padding: 1rem;
-    min-height: 150px;
-  }
-  
-  /* Temporarily adjust calendar during loading to fit screen */
-  .calendar.loading {
-    min-width: auto !important;
-    grid-template-columns: 1fr;
-    padding: 1rem;
   }
 }

--- a/cropCalendar.html
+++ b/cropCalendar.html
@@ -135,7 +135,7 @@
       padding: 0 1.5rem;
     }
 
-    /* Filter Section */
+    /* Filter Section - MODIFIED FOR COUNTRY FILTER */
     .filter-container {
       background: var(--surface-color);
       padding: 1.5rem;
@@ -143,7 +143,8 @@
       box-shadow: var(--shadow-sm);
       display: flex;
       align-items: center;
-      gap: 1rem;
+      justify-content: center;
+      gap: 1.5rem;
       margin-bottom: 2rem;
       border: 1px solid var(--border-color);
       flex-wrap: wrap;
@@ -153,24 +154,9 @@
       font-weight: 600;
       font-family: var(--font-serif);
       font-size: 1.1rem;
-    }
-
-    #cropSelect {
-      padding: 0.6rem 1rem;
-      border-radius: 8px;
-      border: 1px solid var(--border-color);
-      background-color: var(--bg-color);
-      color: var(--text-color);
-      font-size: 1rem;
-      outline: none;
-      cursor: pointer;
-      min-width: 200px;
-      transition: border-color 0.2s;
-    }
-
-    #cropSelect:focus {
-      border-color: var(--accent-color);
-      box-shadow: 0 0 0 3px rgba(22, 163, 74, 0.2);
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
     }
 
     /* Legend */
@@ -213,7 +199,7 @@
       min-width: 800px; /* Ensures grid doesn't squish on small screens */
     }
 
-    /* 5. FOOTER STYLES (Standardized) */
+    /* 5. FOOTER STYLES */
     .site-footer {
       background-color: #1e293b; /* Dark Slate */
       color: #f8fafc;
@@ -322,22 +308,14 @@
 
   <main>
     <div class="filter-container">
-      <label for="cropSelect"><i class="fas fa-filter"></i> Filter by Crop:</label>
+      <label for="countrySelect"><i class="fas fa-globe"></i> Region:</label>
+      <select id="countrySelect">
+        </select>
+
+      <label for="cropSelect"><i class="fas fa-filter"></i> Crop:</label>
       <select id="cropSelect">
         <option value="all">View All Crops</option>
-        <option value="Wheat">Wheat</option>
-        <option value="Rice">Rice</option>
-        <option value="Maize">Maize</option>
-        <option value="Barley">Barley</option>
-        <option value="Sugarcane">Sugarcane</option>
-        <option value="Cotton">Cotton</option>
-        <option value="Groundnut">Groundnut</option>
-        <option value="Soybean">Soybean</option>
-        <option value="Pulses">Pulses</option>
-        <option value="Mustard">Mustard</option>
-        <option value="Sunflower">Sunflower</option>
-        <option value="Jute">Jute</option>
-      </select>
+        </select>
     </div>
 
     <div class="legend">

--- a/cropCalendar.js
+++ b/cropCalendar.js
@@ -1,37 +1,105 @@
-const crops = [
-    { crop: "Wheat", sowing: 11, harvesting: 3 },
-    { crop: "Rice", sowing: 6, harvesting: 10 },
-    { crop: "Maize", sowing: 5, harvesting: 9 },
-    { crop: "Barley", sowing: 11, harvesting: 4 },
-    { crop: "Sugarcane", sowing: 2, harvesting: 12 },
-    { crop: "Cotton", sowing: 6, harvesting: 11 },
-    { crop: "Groundnut", sowing: 6, harvesting: 10 },
-    { crop: "Soybean", sowing: 6, harvesting: 9 },
-    { crop: "Pulses", sowing: 10, harvesting: 3 },
-    { crop: "Mustard", sowing: 10, harvesting: 2 },
-    { crop: "Sunflower", sowing: 1, harvesting: 4 },
-    { crop: "Jute", sowing: 3, harvesting: 7 }
-];
-
+// 1. RESTRUCTURED DATA: Grouped by Country
+const cropData = {
+    "India": [
+        { crop: "Wheat", sowing: 11, harvesting: 3 },
+        { crop: "Rice", sowing: 6, harvesting: 10 },
+        { crop: "Maize", sowing: 5, harvesting: 9 },
+        { crop: "Barley", sowing: 11, harvesting: 4 },
+        { crop: "Sugarcane", sowing: 2, harvesting: 12 },
+        { crop: "Cotton", sowing: 6, harvesting: 11 },
+        { crop: "Groundnut", sowing: 6, harvesting: 10 },
+        { crop: "Soybean", sowing: 6, harvesting: 9 },
+        { crop: "Pulses", sowing: 10, harvesting: 3 },
+        { crop: "Mustard", sowing: 10, harvesting: 2 },
+        { crop: "Sunflower", sowing: 1, harvesting: 4 },
+        { crop: "Jute", sowing: 3, harvesting: 7 }
+    ],
+    "USA": [
+        { crop: "Wheat (Winter)", sowing: 9, harvesting: 7 },
+        { crop: "Corn (Maize)", sowing: 4, harvesting: 10 },
+        { crop: "Soybean", sowing: 5, harvesting: 10 },
+        { crop: "Cotton", sowing: 5, harvesting: 11 },
+        { crop: "Rice", sowing: 4, harvesting: 9 }
+    ],
+    "Australia": [
+        { crop: "Wheat", sowing: 4, harvesting: 11 },
+        { crop: "Barley", sowing: 5, harvesting: 11 },
+        { crop: "Canola", sowing: 4, harvesting: 11 }
+    ]
+};
 
 const months = ["Crop", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 
-function renderCalendar(filter = "all") {
-    const calendar = document.getElementById("calendar");
+// Initialize
+document.addEventListener("DOMContentLoaded", function() {
+    populateCountryDropdown();
+    updateCropDropdown(); // Populate crops based on default country
     
-    // Show loading state
+    const calendar = document.getElementById("calendar");
     showLoadingState(calendar);
     
-    // Simulate loading delay for smooth transition
     setTimeout(() => {
-        renderCalendarContent(filter);
+        renderCalendar();
+    }, 500);
+
+    enableTooltipToggleOnTouch();
+});
+
+
+// Helper: Populate Country Dropdown
+function populateCountryDropdown() {
+    const countrySelect = document.getElementById("countrySelect");
+    const countries = Object.keys(cropData);
+    
+    countries.forEach(country => {
+        const option = document.createElement("option");
+        option.value = country;
+        option.innerText = country;
+        countrySelect.appendChild(option);
+    });
+}
+
+
+// Helper: Update Crop Dropdown based on selected Country
+function updateCropDropdown() {
+    const country = document.getElementById("countrySelect").value;
+    const cropSelect = document.getElementById("cropSelect");
+    
+    // Reset options
+    cropSelect.innerHTML = '<option value="all">View All Crops</option>';
+    
+    // Get crops for selected country
+    const availableCrops = cropData[country] || [];
+    
+    availableCrops.forEach(item => {
+        const option = document.createElement("option");
+        option.value = item.crop;
+        option.innerText = item.crop;
+        cropSelect.appendChild(option);
+    });
+}
+
+
+function renderCalendar() {
+    const calendar = document.getElementById("calendar");
+    // Ensure we get values safely
+    const countrySelect = document.getElementById("countrySelect");
+    const cropSelect = document.getElementById("cropSelect");
+    
+    const countryFilter = countrySelect ? countrySelect.value : "India";
+    const cropFilter = cropSelect ? cropSelect.value : "all";
+
+    showLoadingState(calendar);
+    
+    setTimeout(() => {
+        renderCalendarContent(countryFilter, cropFilter);
     }, 300);
 }
 
+
 function showLoadingState(calendar) {
     calendar.classList.add("loading");
-    
     calendar.innerHTML = `
         <div class="calendar-loading">
             <div class="loading-spinner"></div>
@@ -40,12 +108,13 @@ function showLoadingState(calendar) {
     `;
 }
 
-function renderCalendarContent(filter = "all") {
+
+function renderCalendarContent(country, cropFilter) {
     const calendar = document.getElementById("calendar");
     calendar.innerHTML = "";
-    
     calendar.classList.remove("loading");
     
+    // Render Header Row
     months.forEach((month, index) => {
         const div = document.createElement("div");
         div.className = "month";
@@ -54,10 +123,25 @@ function renderCalendarContent(filter = "all") {
         calendar.appendChild(div);
     });
 
-    // Filter crops
-    const filteredCrops = crops.filter(crop => filter === "all" || crop.crop === filter);
+    // 1. Get crops for the selected country
+    const countryCrops = cropData[country] || [];
+
+    // 2. Filter specific crop if selected
+    const filteredCrops = countryCrops.filter(item => cropFilter === "all" || item.crop === cropFilter);
     
-    // Render crops with staggered animation
+    // If no data found
+    if (filteredCrops.length === 0) {
+        // Create a full-width message
+        const messageDiv = document.createElement("div");
+        messageDiv.style.gridColumn = "1 / -1";
+        messageDiv.style.textAlign = "center";
+        messageDiv.style.padding = "2rem";
+        messageDiv.innerText = "No data available for this selection.";
+        calendar.appendChild(messageDiv);
+        return;
+    }
+
+    // Render Rows
     filteredCrops.forEach((crop, cropIndex) => {
         const row = [crop.crop, ...Array(12).fill("")];
         const start = crop.sowing;
@@ -112,11 +196,11 @@ function renderCalendarContent(filter = "all") {
                     addCellInteractions(div, crop.crop, 'growing');
                 }
             }
-
             calendar.appendChild(div);
         });
     });
 }
+
 
 function addCellInteractions(div, cropName, phase) {
     div.addEventListener("mouseenter", (e) => {
@@ -150,24 +234,46 @@ function addCellInteractions(div, cropName, phase) {
             div.style.transform = "";
         }, 150);
         
-        // Show detailed info (placeholder for future enhancement)
         console.log(`${cropName} - ${phase} phase clicked`);
     });
 }
 
-// Enhanced dropdown event handler with smooth transitions
-document.getElementById("cropSelect").addEventListener("change", function () {
-    const selectedCrop = this.value;
+
+// --- EVENT LISTENERS ---
+
+// 1. Country Selection Change
+document.getElementById("countrySelect").addEventListener("change", function () {
     const calendar = document.getElementById("calendar");
     
-    // Add fade out effect
+    // Visual feedback
+    calendar.style.opacity = "0.5";
+    calendar.style.transform = "translateY(10px)";
+    
+    // Update the Crop list because different countries grow different crops
+    updateCropDropdown();
+
+    setTimeout(() => {
+        renderCalendar();
+        
+        // Fade back in
+        setTimeout(() => {
+            calendar.style.opacity = "1";
+            calendar.style.transform = "translateY(0)";
+        }, 100);
+    }, 200);
+});
+
+
+// 2. Crop Selection Change
+document.getElementById("cropSelect").addEventListener("change", function () {
+    const calendar = document.getElementById("calendar");
+    
     calendar.style.opacity = "0.5";
     calendar.style.transform = "translateY(10px)";
     
     setTimeout(() => {
-        renderCalendar(selectedCrop);
+        renderCalendar();
         
-        // Fade back in
         setTimeout(() => {
             calendar.style.opacity = "1";
             calendar.style.transform = "translateY(0)";
@@ -182,17 +288,6 @@ document.getElementById("cropSelect").addEventListener("keydown", function(e) {
     }
 });
 
-// Initialize calendar with enhanced loading
-document.addEventListener("DOMContentLoaded", function() {
-    // Add initial loading state
-    const calendar = document.getElementById("calendar");
-    showLoadingState(calendar);
-    
-    // Load calendar after a brief delay
-    setTimeout(() => {
-        renderCalendar();
-    }, 500);
-});
 
 function enableTooltipToggleOnTouch() {
   const isTouchDevice = window.matchMedia("(hover: none) and (pointer: coarse)").matches;
@@ -245,7 +340,3 @@ function enableTooltipToggleOnTouch() {
     }
   });
 }
-
-document.addEventListener("DOMContentLoaded", () => {
-  enableTooltipToggleOnTouch();
-});


### PR DESCRIPTION
Description: This PR addresses issue #589 by implementing a "Country/Region" filter to the Crop Calendar. Previously, the calendar displayed a static list of crops (primarily based on Indian seasons) without an option to switch contexts.

With this update, users can first select a country (e.g., India, USA, Australia), and the calendar will dynamically render the crop sowing and harvesting cycles specific to that region. The "Crop" filter has also been updated to be dependent on the selected country, showing only relevant crops.

Related Issue: Fixes #589 

<img width="1592" height="772" alt="image" src="https://github.com/user-attachments/assets/db75497a-aa0d-4785-87e1-65b64d3a6b98" />
