### PR TITLE
feat: implement rate limiting for AI and sensitive endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import os
 import re
 from flask_cors import CORS
 from dotenv import load_dotenv
+from extensions import limiter
 from crop_recommendation.routes import crop_bp
 from disease_prediction.routes import disease_bp
 
@@ -19,6 +20,9 @@ CORS(app, resources={r"/*": {"origins": "http://127.0.0.1:5500"}})
 
 app.register_blueprint(crop_bp)
 app.register_blueprint(disease_bp)
+
+# Initialize Limiter
+limiter.init_app(app)
 
 
 
@@ -69,6 +73,7 @@ model = genai.GenerativeModel("gemini-2.5-flash")
 
 """Secure endpoint to provide Firebase configuration to client"""
 @app.route('/api/firebase-config')
+@limiter.limit("10 per minute")
 def get_firebase_config():
     try:
         return jsonify({
@@ -89,6 +94,7 @@ def get_firebase_config():
 
 
 @app.route('/process-loan', methods=['POST'])
+@limiter.limit("5 per minute")
 def process_loan():
     try:
         json_data = request.get_json(force=True)
@@ -193,6 +199,7 @@ def contact():
     return send_from_directory('.', 'contact.html')
 
 @app.route('/chat')
+@limiter.limit("10 per minute")
 def chat():
     return send_from_directory('.', 'chat.html')
 

--- a/crop_recommendation/routes.py
+++ b/crop_recommendation/routes.py
@@ -2,6 +2,7 @@ from flask import Blueprint, render_template, request, jsonify
 import joblib
 import numpy as np
 import os
+from extensions import limiter
 
 crop_bp = Blueprint(
     'crop',
@@ -29,6 +30,7 @@ def crop_home():
 
 
 @crop_bp.route("/predict", methods=["POST"])
+@limiter.limit("10 per minute")
 def predict():
     try:
         # Match frontend + ML column names

--- a/disease_prediction/routes.py
+++ b/disease_prediction/routes.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, render_template, request, redirect, url_for
 import os
 from werkzeug.utils import secure_filename
+from extensions import limiter
 
 from .utils import load_pytorch_model, predict_image_pytorch
 
@@ -65,6 +66,7 @@ def disease_home():
 
 
 @disease_bp.route("/predict", methods=["POST"])
+@limiter.limit("10 per minute")
 def predict_disease():
     file = request.files.get("file")
 

--- a/extensions.py
+++ b/extensions.py
@@ -1,0 +1,8 @@
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=["200 per day", "50 per hour"],
+    storage_uri="memory://"
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ PyJWT>=2.0
 pytest==7.4.2
 flake8==6.0.0
 Flask
+Flask-Limiter
 Flask-Cors
 Flask-SocketIO
 python-dotenv


### PR DESCRIPTION
### Description
This PR addresses issue #945 by implementing a robust rate-limiting system using `Flask-Limiter`. 

### Changes Made
- Introduced [extensions.py](cci:7://file:///d:/AgriTech/extensions.py:0:0-0:0) to prevent circular imports and centralize the `Limiter` instance.
- Configured a global limit of 200 requests/day to protect the entire application.
- Applied stricter `@limiter.limit` decorators (5-10 per minute) to high-cost endpoints: `/process-loan`, `/crop/predict`, and `/disease/predict`.
- Updated [requirements.txt](cci:7://file:///d:/AgriTech/requirements.txt:0:0-0:0) with `Flask-Limiter`.

### Impact
Protects the Gemini API quota and server resources from automated abuse while maintaining a smooth experience for legitimate users.

Fixes #945