### PR TITLE
fix: resolve poor text visibility on Sustainability Tips cards

### DIFF
--- a/sustainable-farming.html
+++ b/sustainable-farming.html
@@ -8,7 +8,9 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&family=Libertinus+Serif:wght@400;600&display=swap" rel="stylesheet">
+    <link
+        href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&family=Libertinus+Serif:wght@400;600&display=swap"
+        rel="stylesheet">
     <link
         href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&family=Libertinus+Serif:wght@400;600&display=swap"
         rel="stylesheet">
@@ -236,13 +238,16 @@
         .header h1 {
             font-family: 'Libertinus Serif', serif;
             font-size: 2.5rem;
-            color: #ffffff; /* Improved Contrast: Explicitly white */
-            text-shadow: 0 2px 4px rgba(0,0,0,0.3); /* Improved legibility */
+            color: #ffffff;
+            /* Improved Contrast: Explicitly white */
+            text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+            /* Improved legibility */
             margin-bottom: 10px;
         }
 
         .header p {
-            color: #f1f5f9; /* Improved Contrast: Lighter than secondary text */
+            color: #f1f5f9;
+            /* Improved Contrast: Lighter than secondary text */
             font-size: 1.1rem;
         }
 
@@ -274,8 +279,10 @@
         .tool-header h2 {
             font-family: 'Libertinus Serif', serif;
             font-size: 2rem;
-            color: #ffffff; /* Improved Contrast: Explicitly white */
-            text-shadow: 0 1px 3px rgba(0,0,0,0.2); /* Improved visibility */
+            color: #ffffff;
+            /* Improved Contrast: Explicitly white */
+            text-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+            /* Improved visibility */
             margin-bottom: 10px;
         }
 
@@ -388,7 +395,7 @@
             color: var(--text-secondary);
             font-weight: 500;
         }
-        
+
         .practices-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
@@ -438,7 +445,8 @@
         .practice-card h3 {
             font-family: 'Libertinus Serif', serif;
             font-size: 1.5rem;
-            color: #ffffff; /* Improved Contrast */
+            color: #ffffff;
+            /* Improved Contrast */
             margin-bottom: 15px;
         }
 
@@ -481,13 +489,14 @@
 
         .tip-card:hover {
             transform: scale(1.02);
-            box-shadow: 0 8px 25px rgba(0,184,148,0.2);
+            box-shadow: 0 8px 25px rgba(0, 184, 148, 0.2);
             border-left-width: 8px;
         }
 
         .tip-title {
             font-weight: 600;
-            color: #ffffff; /* Improved Contrast */
+            color: #ffffff;
+            /* Improved Contrast */
             margin-bottom: 10px;
             display: flex;
             align-items: center;
@@ -499,10 +508,11 @@
         }
 
         .tip-card p {
-            color: var(--text-secondary);
+            color: #ffffff;
+            /* Improved Contrast: Explicit pure white */
         }
 
-        
+
         .assessment-tool {
             background: rgba(30, 41, 59, 0.95);
             backdrop-filter: blur(10px);
@@ -755,7 +765,8 @@
             .top-nav {
                 position: static;
                 margin-bottom: 1rem;
-                transform: none !important; /* Prevent hiding on mobile for usability */
+                transform: none !important;
+                /* Prevent hiding on mobile for usability */
             }
 
             .floating-tips {


### PR DESCRIPTION
Closes #969 

### **Description:** 
1This PR addresses a critical contrast bug in the sustainable-farming.html page where tip descriptions were rendered in a low-contrast muted green against a dark background.

Key Changes:

- CSS Update: Modified .tip-card p text color to #ffffff (Pure White).

- Accessibility: Ensured the text meets WCAG high-contrast standards for dark-themed components.

BEFORE:
<img width="822" height="259" alt="image" src="https://github.com/user-attachments/assets/3fc3156e-e641-4cc2-bd0c-9a8400fbdca8" />

AFTER:
<img width="1141" height="541" alt="image" src="https://github.com/user-attachments/assets/9a9828a0-70dd-4bfc-b6b8-dc2ddd73b46c" />
