### PR TITLE
Changed footer year to 2026 on About us page

### DIFF
--- a/about.html
+++ b/about.html
@@ -104,7 +104,7 @@
     </main>
 
     <footer class="footer">
-        <p>&copy; 2025 AgriTech. All rights reserved. | Built with 💚 for farmers</p>
+        <p>&copy; 2026 AgriTech. All rights reserved. | Built with 💚 for farmers</p>
     </footer>
 
     <script>


### PR DESCRIPTION
## 📝 Description

This PR updates the footer year displayed on the About Us page from 2025 to 2026 to keep the website content current and accurate.

## 🔧 Changes Made

Updated the footer year to 2026 on the About Us page

No changes to existing layout, styling, or functionality

## ✅ Impact

Improves content accuracy

No breaking changes

Safe UI update

## 🧪 Testing

Verified footer displays © 2026 correctly on the About Us page

Checked responsiveness and consistency with other pages

## 📷 Screenshots (if applicable)


<img width="1891" height="889" alt="image" src="https://github.com/user-attachments/assets/f89d3203-886f-4866-af51-6a4b3c6ab95b" />

This PR #1107 closes issue #1099 