### PR TITLE
Fix Theme Toggle on About Page and Sync Across Pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -92,59 +92,62 @@
     <footer class="footer">
         <p>&copy; 2026 AgriTech. All rights reserved. | Built with 💚 for farmers</p>
     </footer>
+<script>
+function applyTheme(theme) {
+    const html = document.documentElement;
+    html.setAttribute('data-theme', theme);
 
-    <script>
-        // Theme Toggle Script
-        const themeToggle = document.getElementById('themeToggle');
+    const themeLabel = document.querySelector('.theme-label');
+    if (themeLabel) themeLabel.textContent = theme === 'light' ? 'Light' : 'Dark';
+}
+
+function initThemeToggle() {
+    const themeToggle = document.getElementById('themeToggle');
+    if (!themeToggle) return; // navbar not loaded yet
+
+    themeToggle.addEventListener('click', () => {
         const html = document.documentElement;
-        const themeLabel = document.querySelector('.theme-label');
+        const current = html.getAttribute('data-theme');
+        const next = current === 'light' ? 'dark' : 'light';
+        applyTheme(next);
+        localStorage.setItem('agritech-theme', next);
+    });
+}
 
-        // Check for saved theme preference or default to 'light'
-        const currentTheme = localStorage.getItem('theme') || 'light';
-        html.setAttribute('data-theme', currentTheme);
+// Initialize theme on page load
+document.addEventListener('DOMContentLoaded', () => {
+    const savedTheme = localStorage.getItem('agritech-theme') || 'light';
+    applyTheme(savedTheme);
+});
 
-        // Update label on load
-        if (currentTheme === 'dark') {
-            themeLabel.textContent = 'Dark';
-        }
+// Load navbar and attach toggle AFTER navbar is loaded
+function includeHTML() {
+    var z, i, elmnt, file, xhttp;
+    z = document.getElementsByTagName("*");
+    for (i = 0; i < z.length; i++) {
+        elmnt = z[i];
+        file = elmnt.getAttribute("w3-include-html");
+        if (file) {
+            xhttp = new XMLHttpRequest();
+            xhttp.onreadystatechange = function() {
+                if (this.readyState == 4) {
+                    if (this.status == 200) {elmnt.innerHTML = this.responseText;}
+                    if (this.status == 404) {elmnt.innerHTML = "Page not found.";}
+                    elmnt.removeAttribute("w3-include-html");
+                    includeHTML();
 
-        // Theme toggle event listener
-        themeToggle.addEventListener('click', () => {
-            const theme = html.getAttribute('data-theme');
-            const newTheme = theme === 'light' ? 'dark' : 'light';
-            
-            html.setAttribute('data-theme', newTheme);
-            localStorage.setItem('theme', newTheme);
-            
-            themeLabel.textContent = newTheme === 'light' ? 'Light' : 'Dark';
-        });
-    </script>
-
-    <!-- Include Navbar Script -->
-    <script>
-        function includeHTML() {
-            var z, i, elmnt, file, xhttp;
-            z = document.getElementsByTagName("*");
-            for (i = 0; i < z.length; i++) {
-                elmnt = z[i];
-                file = elmnt.getAttribute("w3-include-html");
-                if (file) {
-                    xhttp = new XMLHttpRequest();
-                    xhttp.onreadystatechange = function() {
-                        if (this.readyState == 4) {
-                            if (this.status == 200) {elmnt.innerHTML = this.responseText;}
-                            if (this.status == 404) {elmnt.innerHTML = "Page not found.";}
-                            elmnt.removeAttribute("w3-include-html");
-                            includeHTML();
-                        }
-                    }
-                    xhttp.open("GET", file, true);
-                    xhttp.send();
-                    return;
+                    // ✅ Attach theme toggle AFTER navbar loads
+                    initThemeToggle();
                 }
             }
+            xhttp.open("GET", file, true);
+            xhttp.send();
+            return;
         }
-        includeHTML();
-    </script>
+    }
+}
+includeHTML();
+</script>
+
 </body>
 </html>

--- a/navbar.html
+++ b/navbar.html
@@ -721,11 +721,11 @@
           </div>
         </div>
 
-        <!-- Theme Toggle -->
-        <button class="theme-toggle btn" onclick="toggleTheme()">
-          <i class="fas fa-moon"></i>
-          <span class="theme-text">Light</span>
-        </button>
+       <button id="themeToggle" class="theme-toggle btn">
+  <i class="fas fa-moon"></i>
+  <span class="theme-label">Light</span>
+</button>
+
 
         <!-- Login/Register -->
         <a href="login.html" class="btn btn-secondary">Login</a>


### PR DESCRIPTION
### Description:
This PR fixes the issue where the theme toggle was not working on about.html. Previously, the navbar was loaded asynchronously via w3-include-html, causing the theme toggle button to be unavailable when the page script ran.

### Issue #899

### Changes include:
- Wrapped theme toggle initialization to run after the navbar is loaded.
- Consolidated theme storage to use a single localStorage key (agritech-theme) across all pages.
- Updated navbar.html to include consistent id="themeToggle" and class="theme-label" for proper JS targeting.
- Ensures that the selected theme persists across page loads and works on both desktop and mobile toggles.
- Removed duplicate event listeners for the theme toggle button.

### Screenshot
<img width="1600" height="852" alt="Screenshot 2026-01-25 165855" src="https://github.com/user-attachments/assets/dfc593ba-2f62-4ed7-86a7-b246870bafbc" />
<img width="1600" height="852" alt="Screenshot 2026-01-25 165906" src="https://github.com/user-attachments/assets/8d80fb2b-cb89-4193-b2fe-fb020172fde3" />
