### PR TITLE
Redesign Navigation to Navbar on Careers Page

### DIFF
--- a/carrers.html
+++ b/carrers.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
 </head>
 <body>
+    <div w3-include-html="navbar.html"></div>
 
     <main>
         <section class="career-section">
@@ -178,6 +179,64 @@
              });
         });
     </script>
+    <script src="auth.js"></script>
+    <script>
+function applyTheme(theme) {
+    const html = document.documentElement;
+    html.setAttribute('data-theme', theme);
+
+    // Update labels/icons in navbar if present
+    const themeLabel = document.querySelector('.theme-label');
+    if (themeLabel) themeLabel.textContent = theme === 'light' ? 'Light' : 'Dark';
+}
+
+function initThemeToggle() {
+    const themeToggle = document.getElementById('themeToggle');
+    if (!themeToggle) return; // navbar not loaded yet
+
+    themeToggle.addEventListener('click', () => {
+        const html = document.documentElement;
+        const current = html.getAttribute('data-theme');
+        const next = current === 'light' ? 'dark' : 'light';
+        applyTheme(next);
+        localStorage.setItem('agritech-theme', next);
+    });
+}
+
+// Initialize theme from localStorage
+document.addEventListener('DOMContentLoaded', () => {
+    const savedTheme = localStorage.getItem('agritech-theme') || 'light';
+    applyTheme(savedTheme);
+});
+
+// Load navbar and attach toggle AFTER navbar is loaded
+function includeHTML() {
+    var z, i, elmnt, file, xhttp;
+    z = document.getElementsByTagName("*");
+    for (i = 0; i < z.length; i++) {
+        elmnt = z[i];
+        file = elmnt.getAttribute("w3-include-html");
+        if (file) {
+            xhttp = new XMLHttpRequest();
+            xhttp.onreadystatechange = function() {
+                if (this.readyState == 4) {
+                    if (this.status == 200) {elmnt.innerHTML = this.responseText;}
+                    if (this.status == 404) {elmnt.innerHTML = "Page not found.";}
+                    elmnt.removeAttribute("w3-include-html");
+                    includeHTML();
+
+                    // ✅ Attach theme toggle AFTER navbar loads
+                    initThemeToggle();
+                }
+            }
+            xhttp.open("GET", file, true);
+            xhttp.send();
+            return;
+        }
+    }
+}
+includeHTML();
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
### Problem
The Careers page (carrers.html) does not include navigation links in the footer, forcing users to scroll back to the top to return to Home or access other sections.

### Issue #1144

### ✨ Solution
- Added navigation links to the navbar
- Included Home, About, Services, Careers, Contact
- Ensured consistency with the rest of the site
- Improved user experience and accessibility

### Screenshot
<img width="1600" height="852" alt="image" src="https://github.com/user-attachments/assets/ade6dfb3-a298-4168-b048-ef5801718114" />


@omroy07 merge this issue as  a SWoC26 Contributor