### PR TITLE
Update year on Organic Farming page using dynamic current year

### DIFF
--- a/organic.html
+++ b/organic.html
@@ -203,7 +203,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>© 2026 AgriTech. All rights reserved.</p>
+        <p>© <span id="currentYear"></span> AgriTech. All rights reserved.</p>
       </div>
     </footer>
 
@@ -241,6 +241,10 @@
         const next = current === 'light' ? 'dark' : 'light';
         applyTheme(next);
       });
+    </script>
+    <script>
+      document.getElementById("currentYear").textContent =
+        new Date().getFullYear();
     </script>
   </body>
 </html>

--- a/organic.html.bak
+++ b/organic.html.bak
@@ -196,7 +196,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>© 2025 AgriTech. All rights reserved.</p>
+        <p>© <span id="currentYear"></span> AgriTech. All rights reserved.</p>
       </div>
     </footer>
 
@@ -234,6 +234,10 @@
         const next = current === 'light' ? 'dark' : 'light';
         applyTheme(next);
       });
+    </script>
+    <script>
+      document.getElementById("currentYear").textContent =
+        new Date().getFullYear();
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1228

## Rationale for this change

The Organic Farming page was displaying an outdated year in the footer, which can make the page appear outdated and less actively maintained. Updating the year improves content accuracy, professionalism, and user trust.

## What changes are included in this PR?

- Updated the footer on the Organic Farming page to display the current year
- Replaced the hardcoded year with a dynamic year using JavaScript to prevent future manual updates

## Are these changes tested?

Yes. The page was tested locally in the browser to ensure the correct year is displayed and that no existing functionality or layout is affected.

## Are there any user-facing changes?

Yes. Users will now see the correct, up-to-date year in the footer of the Organic Farming page.
