### PR TITLE
Remove leftover console.log statements from frontend code

### DIFF
--- a/Labour_Alerts/static/script.js
+++ b/Labour_Alerts/static/script.js
@@ -120,7 +120,7 @@ function fetchNewsUpdates() {
         .then(response => response.json())
         .then(data => {
             if (data && Array.isArray(data.results)) {
-                console.log(data);
+                // console.log(data);
                 displayNews(data.results);
             } else {
                 console.error("Invalid data format received:", data);

--- a/blog-backup.html
+++ b/blog-backup.html
@@ -81,7 +81,7 @@
                     this.storageKey = 'agritech_favorite_blogs';
                     this.favorites = JSON.parse(localStorage.getItem(this.storageKey)) || [];
                     window.favoritesManager = this;
-                    console.log('✅ FavoritesManager initialized');
+                    // console.log('✅ FavoritesManager initialized');
                 }
 
                 isFavorite(blogId) {
@@ -176,7 +176,7 @@
 
         // Initialize the blog
         document.addEventListener('DOMContentLoaded', function() {
-            console.log('📄 Blog initialized');
+            // console.log('📄 Blog initialized');
             displayPosts();
             setupEventListeners();
             updateFavoriteCounter();
@@ -222,7 +222,7 @@
                     e.stopPropagation();
                     const button = e.target.closest('.favorite-btn');
                     const blogId = button.getAttribute('data-blog-id');
-                    console.log('❤️ Favorite button clicked:', blogId);
+                    // console.log('❤️ Favorite button clicked:', blogId);
                     toggleFavorite(blogId);
                 }
             });
@@ -297,7 +297,7 @@
 
         // Toggle favorite
         function toggleFavorite(blogId) {
-            console.log('🔄 Toggling favorite for:', blogId);
+            // console.log('🔄 Toggling favorite for:', blogId);
             
             if (!window.favoritesManager) {
                 alert('❌ Favorites feature not loaded');
@@ -414,7 +414,7 @@
 
         // Listen for favorite changes
         document.addEventListener('favoriteToggle', function(event) {
-            console.log('📢 Favorite event:', event.detail);
+            // console.log('📢 Favorite event:', event.detail);
             updateFavoriteButtons(event.detail.blogId);
             updateFavoriteCounter();
         });

--- a/blog.js
+++ b/blog.js
@@ -77,7 +77,7 @@ if (!window.favoritesManager) {
             this.storageKey = 'agritech_favorite_blogs';
             this.favorites = JSON.parse(localStorage.getItem(this.storageKey)) || [];
             window.favoritesManager = this;
-            console.log('✅ FavoritesManager initialized');
+            // console.log('✅ FavoritesManager initialized');
         }
 
         isFavorite(blogId) {
@@ -487,7 +487,7 @@ function displayPosts() {
 
 // Toggle favorite
 function toggleFavorite(blogId) {
-    console.log('🔄 Toggling favorite for:', blogId);
+    // console.log('🔄 Toggling favorite for:', blogId);
 
     if (!window.favoritesManager) {
         alert('❌ Favorites feature not loaded');
@@ -604,7 +604,7 @@ document.getElementById('themeToggle').addEventListener('click', function () {
 
 // Listen for favorite changes
 document.addEventListener('favoriteToggle', function (event) {
-    console.log('📢 Favorite event:', event.detail);
+    // console.log('📢 Favorite event:', event.detail);
     updateFavoriteButtons(event.detail.blogId);
     updateFavoriteCounter();
 });

--- a/src/frontend/js/features/favorites.js
+++ b/src/frontend/js/features/favorites.js
@@ -8,7 +8,7 @@ class FavoritesManager {
 
     init() {
         window.favoritesManager = this;
-        console.log('✅ FavoritesManager loaded with', this.favorites.length, 'favorites');
+        // console.log('✅ FavoritesManager loaded with', this.favorites.length, 'favorites');
         // 🔥 NEW: notify favorites page that data is ready
         document.dispatchEvent(
             new CustomEvent('favoritesLoaded', {
@@ -24,7 +24,7 @@ class FavoritesManager {
     loadFavorites() {
         try {
             const favs = JSON.parse(localStorage.getItem(this.storageKey)) || [];
-            console.log('📁 Loaded favorites:', favs);
+            // console.log('📁 Loaded favorites:', favs);
             return favs;
         } catch (error) {
             console.error('❌ Error loading favorites:', error);
@@ -35,7 +35,7 @@ class FavoritesManager {
     saveFavorites() {
         try {
             localStorage.setItem(this.storageKey, JSON.stringify(this.favorites));
-            console.log('💾 Saved favorites:', this.favorites);
+            // console.log('💾 Saved favorites:', this.favorites);
         } catch (error) {
             console.error('❌ Error saving favorites:', error);
         }
@@ -48,7 +48,7 @@ class FavoritesManager {
         }
 
         if (this.isFavorite(blogData.id)) {
-            console.log('⚠️ Blog already in favorites');
+            // console.log('⚠️ Blog already in favorites');
             return false;
         }
 
@@ -77,10 +77,9 @@ class FavoritesManager {
     }
 
     isFavorite(blogId) {
-        const isFav = this.favorites.some(blog => blog.id === blogId);
-        console.log('🔍 Checking favorite:', blogId, '->', isFav);
-        return isFav;
+        return this.favorites.some(blog => blog.id === blogId);
     }
+
 
     getFavorites() {
         return [...this.favorites].sort(
@@ -93,7 +92,7 @@ class FavoritesManager {
             detail: { blogId, isFavorite, blogData }
         });
         document.dispatchEvent(event);
-        console.log('📢 Dispatched favorite event:', blogId, isFavorite);
+        // console.log('📢 Dispatched favorite event:', blogId, isFavorite);
     }
 
     /* =====================================================
@@ -138,10 +137,10 @@ class FavoritesManager {
 // Initialize when DOM is loaded
 if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {
-        console.log('🚀 Initializing FavoritesManager...');
+        // console.log('🚀 Initializing FavoritesManager...');
         new FavoritesManager();
     });
 } else {
-    console.log('🚀 DOM already loaded, initializing FavoritesManager...');
+    // console.log('🚀 DOM already loaded, initializing FavoritesManager...');
     new FavoritesManager();
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1294

## Rationale for this change

This change removes leftover debugging `console.log()` statements from frontend JavaScript files. These logs caused unnecessary output in the browser console and are not suitable for production environments.

## What changes are included in this PR?

- Removed unused `console.log()` statements from frontend JavaScript and HTML files
- Retained `console.error()` statements for proper error handling
- No functional or UI logic was modified

## Are these changes tested?

Yes. The frontend was manually tested in the browser:
- Pages load correctly
- Favorite functionality and job alerts work as expected
- No unnecessary logs appear in the browser console

Automated tests were not added as this change is a non-functional cleanup and does not alter application behavior.

## Are there any user-facing changes?

No. This change does not introduce any user-facing or UI changes.