### PR TITLE
news: add clear filters control

### DIFF
--- a/news.css
+++ b/news.css
@@ -200,6 +200,29 @@ body {
   color: white;
 }
 
+/* Clear Filters button */
+.clear-filters-btn {
+  margin-top: 0.8rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.clear-filters-btn:hover {
+  color: var(--accent-color);
+  border-color: var(--accent-color);
+}
+
+.clear-filters-btn.hidden {
+  display: none;
+}
+
 /* Empty State */
 .empty-state {
   text-align: center;

--- a/news.html
+++ b/news.html
@@ -26,7 +26,7 @@
           <a href="index.html" class="home-btn">
             <i class="fas fa-arrow-left"></i> Back to Home
           </a>
-          <button class="theme-toggle" id="themeToggle">
+          <button class="theme-toggle" id="themeToggle" type="button">
             <span id="themeIcon">🌙</span>
             <span id="themeText">Dark Mode</span>
           </button>
@@ -48,15 +48,21 @@
           >
           <i class="fas fa-search"></i>
         </div>
+
         <div class="category-filters">
-          <button class="filter-btn active" data-category="all">All News</button>
-          <button class="filter-btn" data-category="market-trends">Market Trends</button>
-          <button class="filter-btn" data-category="technology">Technology</button>
-          <button class="filter-btn" data-category="weather">Weather &amp; Climate</button>
-          <button class="filter-btn" data-category="policy">Policy &amp; Government</button>
-          <button class="filter-btn" data-category="innovation">Innovation</button>
-          <button class="filter-btn" data-category="sustainability">Sustainability</button>
+          <button class="filter-btn active" data-category="all" type="button">All News</button>
+          <button class="filter-btn" data-category="market-trends" type="button">Market Trends</button>
+          <button class="filter-btn" data-category="technology" type="button">Technology</button>
+          <button class="filter-btn" data-category="weather" type="button">Weather &amp; Climate</button>
+          <button class="filter-btn" data-category="policy" type="button">Policy &amp; Government</button>
+          <button class="filter-btn" data-category="innovation" type="button">Innovation</button>
+          <button class="filter-btn" data-category="sustainability" type="button">Sustainability</button>
         </div>
+
+        <!-- Clear Filters Button -->
+        <button id="clearFiltersBtn" class="clear-filters-btn hidden" type="button">
+          Clear Filters
+        </button>
       </div>
 
       <!-- Empty State -->
@@ -74,7 +80,7 @@
 
       <!-- Load More Button -->
       <div class="load-more-container">
-        <button class="load-more-btn" id="loadMoreBtn">Load More News</button>
+        <button class="load-more-btn" id="loadMoreBtn" type="button">Load More News</button>
       </div>
     </div>
   </section>
@@ -84,7 +90,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <h2 class="modal-title" id="modalTitle"></h2>
-        <button class="close" id="closeNewsModal" aria-label="Close modal">&times;</button>
+        <button class="close" id="closeNewsModal" aria-label="Close modal" type="button">&times;</button>
       </div>
       <div class="modal-meta">
         <span id="modal-source">


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1383 

## Rationale for this change

Rationale for this change
This makes filtering news more flexible by allowing up to two categories at once and adds a quick way to reset filters and search.

## What changes are included in this PR?

- Multi‑select category filters (max two) with “All News” as reset.
- New Clear Filters button that resets categories and search.
- Clear Filters only shows when filters or search are active.

<img width="1900" height="836" alt="image" src="https://github.com/user-attachments/assets/858a95d0-b6d4-4473-80b1-b4e9fef24095" />


## Are these changes tested?

Manually tested single and dual category selection, search + filters, empty state, and reset via Clear Filters and Refresh.
All existing behaviors (load more, modal, theme, back‑to‑top, cursor trail) still work as expected.


## Are there any user-facing changes?
Users can now combine two categories when browsing news.
Users see a Clear Filters button in the filter section to quickly return to the default view.
