### PR TITLE
Fix duplicate heart icon appearing outside blog cards

### DIFF
--- a/blog.js
+++ b/blog.js
@@ -491,8 +491,6 @@ function displayPosts() {
                 >
                     <i class="${favoriteIcon}" aria-hidden="true"></i>
                 </button>
-
-                <i class="${favoriteIcon}"></i>
             </button>
             <div class="card-content">
                 <span class="card-category">${post.category.replace('-', ' ')}</span>


### PR DESCRIPTION
## Which issue does this PR close?
An extra heart (favorite) icon was being rendered outside the blog card layout due to a duplicated <i> element in the blog card template. This caused UI misalignment on the Blog page.

- Closes #1359 

## Rationale for this change
The blog cards were rendering an additional heart (favorite) icon outside the intended card layout.
This happened due to a duplicated heart icon element being injected while rendering blog cards, which resulted in UI misalignment and visual clutter.

Removing the duplicate icon ensures the blog card layout remains clean and consistent, while preserving the intended favorite functionality.


## What changes are included in this PR?
- Removed the duplicate heart icon element from the blog card rendering logic
- Ensured only a single favorite button/icon is rendered per blog card
- Kept existing favorites functionality and accessibility attributes unchanged

## Are these changes tested?
Yes.
The fix was verified manually by:
- Loading the blog page
- Confirming that only one heart icon appears per blog card
- Toggling favorite state to ensure functionality remains intact
- Checking that no stray or floating icons appear in the layout
No automated tests were added as this change is limited to a small UI rendering fix and does not affect application logic.

## Are there any user-facing changes?
Yes.
- Users will no longer see an extra heart icon rendered outside blog cards.
- Blog card UI now appears clean and visually consistent.
No documentation updates are required as this change corrects unintended UI behavior.

## Screenshots:
Before:
<img width="1919" height="873" alt="image" src="https://github.com/user-attachments/assets/5ceefb07-546d-44b8-9a0d-9c78dad5337f" />

After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4eb6371a-1eb2-4d40-8480-b85341c1776a" />

---
Note: I have worked on this under `SWOC26`..!

