### PR TITLE
Adding closing feature to alerts

### DIFF
--- a/crop.html
+++ b/crop.html
@@ -1029,6 +1029,33 @@
             max-width: 300px;
         }
 
+        .notification-content {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.notification-text {
+    flex: 1;
+}
+
+.notification-close {
+    background: transparent;
+    border: none;
+    color: white;
+    font-size: 18px;
+    cursor: pointer;
+    margin-left: 10px;
+    line-height: 1;
+    opacity: 0.9;
+}
+
+.notification-close:hover {
+    opacity: 1;
+    transform: scale(1.1);
+}
+
+
         .notification.show {
             transform: translateX(0);
         }
@@ -1891,33 +1918,50 @@
         }
 
         // Notification System
-        function showNotification(message, type = 'success') {
-            const notification = document.createElement('div');
-            notification.className = `notification ${type}`;
+        // Notification System (UPDATED with Close Button + Better Dismiss)
+function showNotification(message, type = 'success') {
+    const notification = document.createElement('div');
+    notification.className = `notification ${type}`;
 
-            const icons = {
-                success: 'fa-check-circle',
-                warning: 'fa-exclamation-triangle',
-                danger: 'fa-exclamation-circle',
-                info: 'fa-info-circle'
-            };
+    const icons = {
+        success: 'fa-check-circle',
+        warning: 'fa-exclamation-triangle',
+        danger: 'fa-exclamation-circle',
+        info: 'fa-info-circle'
+    };
 
-            notification.innerHTML = `
-                <i class="fas ${icons[type]}"></i>
-                <span style="margin-left: 10px;">${message}</span>
-            `;
+    // Create content wrapper
+    notification.innerHTML = `
+        <div class="notification-content">
+            <i class="fas ${icons[type]}"></i>
+            <span class="notification-text">${message}</span>
+            <button class="notification-close" aria-label="Close">&times;</button>
+        </div>
+    `;
 
-            document.body.appendChild(notification);
+    document.body.appendChild(notification);
 
-            setTimeout(() => {
-                notification.classList.add('show');
-            }, 100);
+    // Show animation
+    setTimeout(() => {
+        notification.classList.add('show');
+    }, 100);
 
-            setTimeout(() => {
-                notification.classList.remove('show');
-                setTimeout(() => notification.remove(), 300);
-            }, 4000);
+    // Close button logic (NEW)
+    const closeBtn = notification.querySelector('.notification-close');
+    closeBtn.addEventListener('click', () => {
+        notification.classList.remove('show');
+        setTimeout(() => notification.remove(), 300);
+    });
+
+    // Auto dismiss (still keeps UX smooth)
+    setTimeout(() => {
+        if (notification.parentElement) {
+            notification.classList.remove('show');
+            setTimeout(() => notification.remove(), 300);
         }
+    }, 4000);
+}
+
 
         // Sensor Time Updates
         function updateSensorTimes() {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #1528 

## Rationale for this change
The Smart Crop Monitoring panel currently displays toast notifications (e.g., threshold updates and system alerts) without any manual dismiss option.
These alerts stay visible for a fixed duration and can overlap important UI components such as the Settings panel, export buttons, and monitoring controls, negatively affecting usability and accessibility during real-time interaction.

Adding a close (×) button allows users to instantly dismiss non-critical alerts instead of waiting for auto-dismiss, improving overall dashboard UX and aligning with standard notification behavior in modern web applications.

## What changes are included in this PR?
Updated the notification/toast system in crop.html
Added a dismiss (×) close button inside each toast notification
Implemented click handler to instantly remove the toast from the DOM
Retained existing auto-dismiss functionality (4 seconds) for non-intrusive UX
Added new CSS styles for:
.notification-content
.notification-text
.notification-close
Ensured smooth animation is preserved during appearance and dismissal
No changes to existing dashboard logic, data flow, or API behavior

## Are these changes tested?
Yes.
The changes were manually tested in the browser by triggering multiple notification scenarios including:
Threshold slider updates (moisture & temperature)
Theme toggle notifications
Data refresh and export alerts
View switching alerts
Verified that:
Close (×) button dismisses notifications instantly
Auto-dismiss still works correctly after 4 seconds
No console errors occur
No layout breakage in both dark and light themes
Notifications no longer obstruct critical UI elements
Since this is a UI enhancement and does not affect backend logic, automated tests were not required.

## Are there any user-facing changes?
Yes.
Users will now see a close (×) button on toast notifications in the Smart Crop Monitoring panel, allowing manual dismissal of alerts.
This improves:
Usability during real-time monitoring
Accessibility
Control over intrusive UI elements
There are no breaking changes, and the existing notification behavior and styling remain consistent with the current design.


<img width="1919" height="1015" alt="Screenshot 2026-02-18 112333" src="https://github.com/user-attachments/assets/34f3ffce-f6ef-4fc7-860d-6d9273627164" />
