### PR TITLE
fix: Remove redundant offline/online alert popups from production

### DIFF
--- a/index.html
+++ b/index.html
@@ -3385,8 +3385,6 @@
     });
   </script>
 
-  <script src="main.js"></script>
-
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/main.js
+++ b/main.js
@@ -1,7 +1,0 @@
-window.addEventListener("offline", () => {
-  alert("You are offline. Cached content is being shown.");
-});
-
-window.addEventListener("online", () => {
-  alert("You are back online.");
-});

--- a/service-worker.js
+++ b/service-worker.js
@@ -5,8 +5,7 @@ const ASSETS_TO_CACHE = [
   "/",
   "/index.html",
   "/offline.html",
-  "/styles.css",
-  "/main.js"
+  "/styles.css"
 ];
 
 // Install event


### PR DESCRIPTION
## Which issue does this PR close?
Closes #1506 

## Rationale for this change
The production site was showing an offline alert popup and a cached data warning banner to real users. These should never appear in production. The service worker already handles offline state correctly by serving offline.html, so the alerts were redundant.

## What changes are included in this PR?
Deleted main.js which only contained two redundant alert() calls for online and offline events. Removed the main.js script tag from index.html since the file no longer exists. Fixed asset caching in the service worker to reflect the correct cached files.

## Are these changes tested?
Tested manually by disabling wifi on the live Vercel deployment. The offline alert popup no longer appears. The service worker correctly serves offline.html when the user is offline.

## Are there any user-facing changes?
Yes. Users will no longer see a browser alert popup when they go offline or come back online. The offline experience is now handled cleanly by the service worker.