### PR TITLE
Add workflow in github actions which automatically adds NSOC'26 label to each issue opend 

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -1,8 +1,9 @@
-name: Auto add ECWoC26 label to Issues
+name: Auto add NSOC'26 label to Issues
 
 on:
   issues:
-    types: [opened]
+    types:
+      - opened
 
 permissions:
   issues: write
@@ -11,8 +12,9 @@ permissions:
 jobs:
   add-label:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Add ECWoC26 label to issue
+      - name: Add NSOC'26 label to issue
         uses: actions/github-script@v7
         with:
           script: |
@@ -20,5 +22,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              labels: ["ECWoC26"],
+              labels: ["NSOC'26"],
             });


### PR DESCRIPTION
Add workflow in github actions which automatically adds NSOC'26 label to each issue opend 

Issue : #1708

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
