### PR TITLE
[REFACTOR] Decouple Configuration from Source Code 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,52 @@
+# Example environment file for AgriTech
+# Copy this to `.env` and fill values for local development.
+
+# Flask / App
+FLASK_ENV=development
+DEBUG=True
+SECRET_KEY=
+
+# Database
+DATABASE_URL=sqlite:///agritech_dev.db
+DEV_DATABASE_URL=sqlite:///agritech_dev.db
+
+# JWT / Auth
+JWT_SECRET=
+
+# Gemini / AI
+GEMINI_API_KEY=
+GEMINI_MODEL_ID=gemini-2.5-flash
+
+# Firebase
+FIREBASE_API_KEY=
+FIREBASE_AUTH_DOMAIN=
+FIREBASE_PROJECT_ID=
+FIREBASE_STORAGE_BUCKET=
+FIREBASE_MESSAGING_SENDER_ID=
+FIREBASE_APP_ID=
+FIREBASE_MEASUREMENT_ID=
+
+# Mail
+MAIL_SERVER=smtp.gmail.com
+MAIL_PORT=587
+MAIL_USE_TLS=True
+MAIL_USERNAME=
+MAIL_PASSWORD=
+MAIL_DEFAULT_SENDER=
+
+# Redis / Cache
+REDIS_URL=redis://localhost:6379/0
+
+# Celery
+CELERY_BROKER_URL=redis://localhost:6379/0
+CELERY_RESULT_BACKEND=redis://localhost:6379/0
+
+# S3 / Storage (if using S3)
+S3_BUCKET=
+S3_ACCESS_KEY=
+S3_SECRET_KEY=
+S3_REGION=us-east-1
+S3_ENDPOINT_URL=
+
+# Other
+WEATHER_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,11 @@ logs/
 
 # Environment files
 .env
-.env.*
+.env.local
+.env.development
+.env.production
+.env.test
+.env.*.local
 application-local.yml
 application-dev.yml
 

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -1,9 +1,22 @@
 import os
 
+from dotenv import load_dotenv
+
+
+load_dotenv(
+    dotenv_path=os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '..', '..', '.env')
+    )
+)
+
+
+def _env_bool(name, default=False):
+    return os.environ.get(name, str(default)).strip().lower() in {'1', 'true', 'yes', 'on'}
+
 class Config:
     """Base Configuration"""
-    SECRET_KEY = os.environ.get('SECRET_KEY', 'default_secret_key')
-    DEBUG = False
+    SECRET_KEY = os.environ.get('SECRET_KEY')
+    DEBUG = _env_bool('DEBUG', False)
     TESTING = False
     
     # Database
@@ -58,13 +71,13 @@ class Config:
 
 class DevelopmentConfig(Config):
     """Development Configuration"""
-    DEBUG = True
+    DEBUG = _env_bool('DEBUG', True)
     SQLALCHEMY_DATABASE_URI = os.environ.get('DEV_DATABASE_URL', 'sqlite:///agritech_dev.db')
     SQLALCHEMY_ECHO = False  # Log SQL queries in development
 
 class ProductionConfig(Config):
     """Production Configuration"""
-    DEBUG = False
+    DEBUG = _env_bool('DEBUG', False)
     @classmethod
     def init_app(cls, app):
         if not os.environ.get('GEMINI_API_KEY'):


### PR DESCRIPTION
The refactor is in place on the actual config path this app uses: __init__.py now loads `.env` at startup, reads `SECRET_KEY` and `DEBUG` from the environment, and no longer falls back to a hardcoded secret. I also normalized .env.example into a single clean template and tightened .gitignore so it ignores real env files without accidentally hiding the example file.

Validation passed with `py_compile` plus an import check against the project venv. The only extra step was installing `python-dotenv` into the local virtual environment so that runtime validation could import the package; the repository already declares it in requirements.txt.

closes #576


@omroy07 