### PR TITLE
Make Navigation Bar Static Across Pages

### DIFF
--- a/Forum/forum.html
+++ b/Forum/forum.html
@@ -4,18 +4,57 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Join the AgriTech Community Forum to share advice, ask questions, and discuss farming topics with other farmers." />
   <title>Community Forum - AgriTech</title>
-  
-  <link rel="icon" type="image/png" href="../images/logo.png" />
 
+  <link rel="icon" type="image/png" href="../images/logo.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&family=Libertinus+Serif:wght@400;600&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
+  <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11" defer></script>
 
-  <link rel="stylesheet" href="../theme.css" />
+  <script>
+    (function () {
+      const saved = localStorage.getItem('theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      document.documentElement.setAttribute('data-theme', saved || (prefersDark ? 'dark' : 'light'));
+    })();
+  </script>
+
   <style>
-    /* 1. LAYOUT & RESET */
+    :root {
+      --bg-main: #eef2f7;
+      --bg-accent: rgba(22, 163, 74, 0.12);
+      --surface: rgba(255, 255, 255, 0.78);
+      --surface-strong: #ffffff;
+      --text-main: #0f172a;
+      --text-muted: #5b6474;
+      --border: rgba(15, 23, 42, 0.08);
+      --shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+      --primary: #16a34a;
+      --primary-strong: #15803d;
+      --primary-soft: rgba(22, 163, 74, 0.12);
+      --ring: rgba(22, 163, 74, 0.22);
+      --card-radius: 24px;
+    }
+
+    html[data-theme='dark'] {
+      --bg-main: #0b1120;
+      --bg-accent: rgba(56, 189, 248, 0.12);
+      --surface: rgba(17, 24, 39, 0.92);
+      --surface-strong: #111827;
+      --text-main: #e5e7eb;
+      --text-muted: #94a3b8;
+      --border: rgba(148, 163, 184, 0.16);
+      --shadow: 0 24px 60px rgba(0, 0, 0, 0.38);
+      --primary: #22c55e;
+      --primary-strong: #16a34a;
+      --primary-soft: rgba(34, 197, 94, 0.14);
+      --ring: rgba(34, 197, 94, 0.24);
+    }
+
     * {
       box-sizing: border-box;
       margin: 0;
@@ -23,588 +62,470 @@
     }
 
     body {
-      font-family: 'Open Sans', sans-serif;
-      background-color: var(--bg-secondary, #f8fafc);
-      color: var(--text-primary, #333);
-      line-height: 1.6;
-      display: flex;
-      flex-direction: column;
       min-height: 100vh;
-      transition: background 0.3s, color 0.3s;
+      font-family: 'Outfit', sans-serif;
+      color: var(--text-main);
+      background:
+        radial-gradient(circle at top left, var(--bg-accent), transparent 28%),
+        radial-gradient(circle at top right, rgba(245, 158, 11, 0.08), transparent 24%),
+        linear-gradient(180deg, var(--bg-main), var(--bg-main));
+      line-height: 1.6;
+      transition: background 0.35s ease, color 0.35s ease;
     }
 
-    /* 2. HEADER (Matches Index/Blog) */
-    .navbar {
-      background: var(--bg-primary, #ffffff);
-      padding: 1rem 2rem;
-      border-bottom: 1px solid var(--border-color, #e2e8f0);
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      position: sticky;
-      top: 0;
-      z-index: 100;
-      box-shadow: 0 2px 10px rgba(0,0,0,0.05);
-    }
-
-    .brand {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      font-family: 'Libertinus Serif', serif;
-      font-size: 1.5rem;
-      font-weight: 700;
-      color: var(--primary-green, #16a34a);
+    a {
+      color: inherit;
       text-decoration: none;
     }
 
+    button,
+    input,
+    textarea {
+      font: inherit;
+    }
+
+    .forum-topbar {
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      backdrop-filter: blur(18px);
+      -webkit-backdrop-filter: blur(18px);
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+    }
+
+    .forum-topbar-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 1rem 1.25rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+
+    .forum-branding {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      min-width: 0;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.65rem;
+      font-weight: 800;
+      letter-spacing: 0.01em;
+      color: var(--text-main);
+      white-space: nowrap;
+    }
+
     .brand img {
-      height: 40px;
+      width: 42px;
+      height: 42px;
+      border-radius: 14px;
+      object-fit: cover;
+      box-shadow: var(--shadow);
+    }
+
+    .forum-title-block {
+      min-width: 0;
+    }
+
+    .forum-eyebrow,
+    .section-eyebrow {
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--primary);
+      margin-bottom: 0.2rem;
+    }
+
+    .forum-title-block h1,
+    .section-heading h2 {
+      font-size: clamp(1.25rem, 2vw, 1.8rem);
+      line-height: 1.2;
     }
 
     .nav-actions {
       display: flex;
       align-items: center;
-      gap: 1rem;
+      gap: 0.75rem;
+      flex-shrink: 0;
     }
 
-    /* 3. BUTTONS */
     .btn {
-      padding: 0.6rem 1.2rem;
-      border-radius: 8px;
-      font-weight: 500;
-      cursor: pointer;
-      text-decoration: none;
+      border: 1px solid transparent;
+      border-radius: 999px;
+      min-height: 44px;
+      padding: 0.75rem 1.05rem;
       display: inline-flex;
       align-items: center;
-      gap: 0.5rem;
-      transition: all 0.2s ease;
-      border: 1px solid transparent;
+      justify-content: center;
+      gap: 0.55rem;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+    }
+
+    .btn:hover {
+      transform: translateY(-1px);
     }
 
     .btn-secondary {
-      background: transparent;
-      border-color: var(--border-color, #cbd5e1);
-      color: var(--text-primary, #333);
+      background: var(--surface);
+      color: var(--text-main);
+      border-color: var(--border);
+      box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
     }
 
     .btn-secondary:hover {
-      background: var(--bg-secondary, #f1f5f9);
-      border-color: var(--primary-green, #16a34a);
+      border-color: var(--primary);
+      box-shadow: 0 10px 24px rgba(15, 23, 42, 0.09);
     }
 
     .btn-primary {
-      background: var(--primary-green, #16a34a);
-      color: white;
+      background: linear-gradient(135deg, var(--primary), var(--primary-strong));
+      color: #ffffff;
+      box-shadow: 0 16px 30px rgba(22, 163, 74, 0.24);
     }
 
     .btn-primary:hover {
-      background: #15803d;
+      box-shadow: 0 18px 34px rgba(22, 163, 74, 0.28);
     }
 
-    /* Theme Toggle */
     .theme-toggle {
-      background: transparent;
-      border: 1px solid var(--border-color, #cbd5e1);
-      color: var(--text-primary);
-      width: 40px;
-      height: 40px;
+      width: 44px;
+      height: 44px;
       border-radius: 50%;
-      display: flex;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text-main);
+      display: inline-flex;
       align-items: center;
       justify-content: center;
       cursor: pointer;
-      font-size: 1.2rem;
+      box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+      transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
     }
 
-    /* 4. MAIN CONTAINER */
-    .forum-container {
-      max-width: 900px;
-      width: 100%;
-      margin: 2rem auto;
-      padding: 0 1.5rem;
-      flex: 1;
+    .theme-toggle:hover {
+      transform: translateY(-1px);
+      border-color: var(--primary);
     }
 
-    .forum-header {
-      text-align: center;
-      margin-bottom: 3rem;
+    .forum-shell {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 1.5rem 1.25rem 3rem;
     }
 
-    .forum-header h1 {
-      font-family: 'Libertinus Serif', serif;
-      font-size: 2.5rem;
-      color: var(--primary-green, #16a34a);
-      margin-bottom: 0.5rem;
+    .forum-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+      gap: 1.25rem;
+      align-items: start;
     }
 
-    .forum-header p {
-      color: var(--text-secondary, #64748b);
-      font-size: 1.1rem;
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--card-radius);
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(18px);
+      -webkit-backdrop-filter: blur(18px);
     }
 
-    /* 5. CREATE POST FORM */
-    .create-post-card {
-      background: var(--bg-primary, #ffffff);
-      padding: 2rem;
-      border-radius: 16px;
-      box-shadow: 0 4px 6px rgba(0,0,0,0.05);
-      border: 1px solid var(--border-color, #e2e8f0);
-      margin-bottom: 3rem;
+    .create-post-card,
+    .posts-card {
+      padding: 1.5rem;
     }
 
-    .create-post-card h2 {
-      margin-bottom: 1.5rem;
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      font-size: 1.5rem;
-    }
-
-    .form-group {
+    .section-heading {
+      display: grid;
+      gap: 0.35rem;
       margin-bottom: 1.25rem;
     }
 
+    .section-heading p:last-child {
+      color: var(--text-muted);
+      max-width: 60ch;
+    }
+
+    .section-heading-row {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+
+    .composer-form {
+      display: grid;
+      gap: 1rem;
+    }
+
     .form-group label {
-      display: block;
-      margin-bottom: 0.5rem;
+      display: inline-block;
+      margin-bottom: 0.45rem;
+      font-size: 0.95rem;
       font-weight: 600;
-      font-size: 0.9rem;
     }
 
     .form-control {
       width: 100%;
-      padding: 0.8rem 1rem;
-      border: 1px solid var(--border-color, #cbd5e1);
-      border-radius: 8px;
-      font-family: inherit;
-      background: var(--bg-secondary, #f8fafc);
-      color: var(--text-primary, #333);
-      transition: border 0.2s;
-    }
-
-    .form-control:focus {
+      min-height: 44px;
+      padding: 0.9rem 1rem;
+      border-radius: 16px;
+      border: 1px solid var(--border);
+      background: var(--surface-strong);
+      color: var(--text-main);
       outline: none;
-      border-color: var(--primary-green, #16a34a);
-      box-shadow: 0 0 0 3px rgba(22, 163, 74, 0.1);
+      transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
     }
 
     textarea.form-control {
+      min-height: 180px;
       resize: vertical;
-      min-height: 120px;
     }
 
-    /* 6. POSTS FEED */
-    .feed-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      margin-bottom: 1.5rem;
-      border-bottom: 2px solid var(--border-color, #e2e8f0);
-      padding-bottom: 1rem;
+    .form-control::placeholder {
+      color: var(--text-muted);
+    }
+
+    .form-control:focus {
+      border-color: var(--primary);
+      box-shadow: 0 0 0 4px var(--ring);
+    }
+
+    .submit-btn {
+      width: 100%;
+    }
+
+    #forumPosts {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .forum-post,
+    .empty-state-card {
+      background: var(--surface-strong);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      padding: 1.2rem 1.25rem;
+      box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
     }
 
     .forum-post {
-      background: var(--bg-primary, #ffffff);
-      border: 1px solid var(--border-color, #e2e8f0);
-      border-radius: 12px;
-      padding: 1.5rem;
-      margin-bottom: 1.5rem;
-      transition: transform 0.2s, box-shadow 0.2s;
+      display: grid;
+      gap: 0.9rem;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
     }
 
     .forum-post:hover {
       transform: translateY(-2px);
-      box-shadow: 0 10px 15px rgba(0,0,0,0.05);
+      border-color: var(--primary);
+      box-shadow: 0 16px 30px rgba(15, 23, 42, 0.08);
     }
 
     .post-meta {
       display: flex;
       align-items: center;
-      gap: 0.8rem;
-      margin-bottom: 1rem;
-      font-size: 0.9rem;
-      color: var(--text-secondary, #64748b);
+      gap: 0.85rem;
+      color: var(--text-muted);
+      font-size: 0.93rem;
+      flex-wrap: wrap;
     }
 
     .author-avatar {
-      width: 32px;
-      height: 32px;
-      background: var(--bg-secondary, #e2e8f0);
-      border-radius: 50%;
-      display: flex;
+      width: 42px;
+      height: 42px;
+      border-radius: 14px;
+      background: var(--primary-soft);
+      color: var(--primary);
+      display: inline-flex;
       align-items: center;
       justify-content: center;
-      color: var(--primary-green, #16a34a);
+      flex-shrink: 0;
     }
 
     .post-title {
-      font-size: 1.25rem;
-      font-weight: 700;
-      margin-bottom: 0.75rem;
-      color: var(--primary-green, #16a34a);
+      font-size: 1.08rem;
+      line-height: 1.35;
     }
 
     .post-content {
-      color: var(--text-primary, #333);
-      line-height: 1.7;
+      color: var(--text-muted);
+      display: -webkit-box;
+      -webkit-line-clamp: 4;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      line-height: 1.65;
     }
 
-    /* 7. FOOTER (Standardized) */
-    .site-footer {
-      background: #1e293b; /* Dark Slate */
-      color: #f8fafc;
-      padding: 4rem 2rem 2rem;
-      margin-top: auto;
-    }
-
-    .footer-inner {
-      max-width: 1200px;
-      margin: 0 auto;
+    .empty-state-card {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-      gap: 3rem;
-    }
-
-    .footer-brand h3 {
-      font-family: 'Libertinus Serif', serif;
-      font-size: 1.8rem;
-      color: var(--accent-green, #4ade80);
-      margin-bottom: 1rem;
-      display: flex;
-      align-items: center;
-      gap: 10px;
-    }
-
-    .footer-brand p {
-      opacity: 0.8;
-      line-height: 1.6;
-    }
-
-    .footer-links h4 {
-      color: #fff;
-      margin-bottom: 1.5rem;
-      font-family: 'Libertinus Serif', serif;
-      font-size: 1.2rem;
-      position: relative;
-      display: inline-block;
-    }
-    
-    .footer-links h4::after {
-      content: '';
-      position: absolute;
-      bottom: -5px;
-      left: 0;
-      width: 40px;
-      height: 2px;
-      background: var(--accent-green, #4ade80);
-    }
-
-    .footer-links ul {
-      list-style: none;
-    }
-
-    .footer-links a {
-      color: #cbd5e1;
-      text-decoration: none;
-      display: block;
-      margin-bottom: 0.8rem;
-      transition: color 0.2s;
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-
-    .footer-links a:hover {
-      color: var(--accent-green, #4ade80);
-      transform: translateX(5px);
-    }
-
-    .social-media {
-      display: flex;
-      gap: 1rem;
-      margin-top: 1.5rem;
-    }
-
-    .social-media a {
-      width: 40px;
-      height: 40px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: rgba(255,255,255,0.1);
-      border-radius: 50%;
-      color: white;
-      text-decoration: none;
-      transition: all 0.3s;
-    }
-
-    .social-media a:hover {
-      background: var(--accent-green, #4ade80);
-      color: #1e293b;
-      transform: translateY(-3px);
-    }
-
-    .footer-bottom {
+      place-items: center;
+      gap: 0.5rem;
+      min-height: 180px;
+      color: var(--text-muted);
       text-align: center;
-      margin-top: 3rem;
-      padding-top: 2rem;
-      border-top: 1px solid rgba(255,255,255,0.1);
-      color: #94a3b8;
-      font-size: 0.9rem;
+      border-style: dashed;
     }
 
-    /* Responsive */
-    @media (max-width: 768px) {
-      .navbar {
-        padding: 1rem;
+    .empty-state-card i {
+      font-size: 1.3rem;
+      color: var(--primary);
+    }
+
+    .empty-state-card p {
+      margin: 0;
+    }
+
+    @media (max-width: 900px) {
+      .forum-grid {
+        grid-template-columns: 1fr;
       }
-      .brand span {
+    }
+
+    @media (max-width: 720px) {
+      .forum-topbar-inner {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .forum-branding {
+        justify-content: space-between;
+      }
+
+      .nav-actions {
+        justify-content: space-between;
+      }
+
+      .section-heading-row {
+        flex-direction: column;
+      }
+
+      .forum-shell {
+        padding-inline: 1rem;
+      }
+
+      .create-post-card,
+      .posts-card {
+        padding: 1.25rem;
+      }
+
+      .brand span,
+      .back-link span {
         display: none;
       }
-      .forum-container {
-        padding: 0 1rem;
-      }
-      .forum-header h1 {
-        font-size: 2rem;
-      }
     }
-       /* --- Cursor Trail Container --- */
-.circle-container {
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: 999999;
-}
-
-/* --- Individual Trail Circles --- */
-.cursor-circle {
-  position: absolute;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background-color: #ff8c00;
-  box-shadow: 0 0 15px rgba(255, 140, 0, 0.7);
-  transform: translate(-50%, -50%);
-  will-change: transform;
-  mix-blend-mode: screen;
-  transition: transform 0.1s ease-out;
-}
-
-/* --- The Leading "Head" Circle --- */
-.cursor-circle:first-child {
-  width: 14px;
-  height: 14px;
-  background-color: #ffcc00;
-  box-shadow:
-    0 0 20px #ff8c00,
-    0 0 40px rgba(255, 140, 0, 0.5);
-}
-
-/* --- Interaction States --- */
-.cursor-clicking {
-  transform: translate(-50%, -50%) scale(2.5) !important;
-  background-color: #ffffff !important;
-  box-shadow: 0 0 30px #ffffff !important;
-}
-
-.cursor-hovering {
-  transform: translate(-50%, -50%) scale(1.8);
-  background-color: #22c55e; /* AgriTech green */
-  box-shadow: 0 0 20px #22c55e;
-}
   </style>
 </head>
 
 <body>
+  <header class="forum-topbar">
+    <div class="forum-topbar-inner">
+      <div class="forum-branding">
+        <a href="../index.html" class="brand" aria-label="AgriTech home">
+          <img src="../images/logo.png" alt="AgriTech logo" />
+          <span>AgriTech</span>
+        </a>
 
-  <nav class="navbar">
-    <a href="../index.html" class="brand">
-      <img src="../images/logo.png" alt="Logo">
-      <span>AgriTech</span>
-    </a>
-
-    <div class="nav-actions">
-      <a href="../index.html" class="btn btn-secondary">
-        <i class="fas fa-arrow-left"></i> Home
-      </a>
-      
-      <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
-        <i class="fas fa-moon"></i>
-      </button>
-    </div>
-  </nav>
-
-  <main class="forum-container">
-    <div class="forum-header">
-      <h1>Community Forum</h1>
-      <p>Connect, share, and learn from fellow farmers.</p>
-    </div>
-
-    <section class="create-post-card">
-      <h2><i class="fas fa-pen-to-square"></i> Start a Discussion</h2>
-      <form id="forumForm">
-        <div class="form-group">
-          <label for="title">Discussion Title</label>
-          <input type="text" id="title" name="title" class="form-control" placeholder="e.g., Best organic fertilizer for wheat?" required maxlength="200">
-        </div>
-
-        <div class="form-group">
-          <label for="author">Your Name</label>
-          <input type="text" id="author" name="author" class="form-control" placeholder="Enter your name" required maxlength="100">
-        </div>
-
-        <div class="form-group">
-          <label for="content">Message</label>
-          <textarea id="content" name="content" class="form-control" placeholder="Share your experience or ask a question..." required maxlength="5000"></textarea>
-        </div>
-
-        <button type="submit" class="btn btn-primary">
-          <i class="fas fa-paper-plane"></i> Post Discussion
-        </button>
-      </form>
-    </section>
-
-    <section>
-      <div class="feed-header">
-        <h2>Recent Discussions</h2>
-        <button class="btn btn-secondary" onclick="loadPosts()">
-          <i class="fas fa-sync-alt"></i> Refresh
-        </button>
-      </div>
-      
-      <div id="forumPosts">
-        <div style="text-align: center; padding: 2rem; color: #64748b;">
-          <i class="fas fa-spinner fa-spin"></i> Loading discussions...
+        <div class="forum-title-block">
+          <p class="forum-eyebrow">Farmer Forum</p>
+          <h1>Community Forum</h1>
         </div>
       </div>
+
+      <div class="nav-actions">
+        <a href="../index.html" class="btn btn-secondary back-link">
+          <i class="fas fa-arrow-left"></i>
+          <span>Back to Main Page</span>
+        </a>
+
+        <button class="theme-toggle" id="themeToggle" type="button" aria-label="Toggle theme">
+          <i class="fas fa-moon"></i>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main class="forum-shell">
+    <section class="forum-grid" aria-label="Forum content">
+      <article class="card create-post-card">
+        <div class="section-heading">
+          <p class="section-eyebrow">Create a Post</p>
+          <h2>Start a conversation</h2>
+          <p>Share advice, ask a question, or post an update for other farmers.</p>
+        </div>
+
+        <form id="forumForm" class="composer-form">
+          <div class="form-group">
+            <label for="title">Discussion Title</label>
+            <input type="text" id="title" name="title" class="form-control" placeholder="e.g., Best organic fertilizer for wheat?" required maxlength="200" />
+          </div>
+
+          <div class="form-group">
+            <label for="author">Your Name</label>
+            <input type="text" id="author" name="author" class="form-control" placeholder="Enter your name" required maxlength="100" />
+          </div>
+
+          <div class="form-group">
+            <label for="content">Message</label>
+            <textarea id="content" name="content" class="form-control" placeholder="Share your experience or ask a question..." required maxlength="5000"></textarea>
+          </div>
+
+          <button type="submit" class="btn btn-primary submit-btn">
+            <i class="fas fa-paper-plane"></i> Post Discussion
+          </button>
+        </form>
+      </article>
+
+      <article class="card posts-card">
+        <div class="section-heading section-heading-row">
+          <div>
+            <p class="section-eyebrow">Recent Posts</p>
+            <h2>Latest community discussions</h2>
+            <p>Browse the newest advice, questions, and shared experiences.</p>
+          </div>
+
+          <button class="btn btn-secondary" type="button" onclick="loadPosts()">
+            <i class="fas fa-sync-alt"></i>
+            Refresh
+          </button>
+        </div>
+
+        <div id="forumPosts">
+          <div class="empty-state-card">
+            <i class="fas fa-spinner fa-spin"></i>
+            <p>Loading discussions...</p>
+          </div>
+        </div>
+      </article>
     </section>
   </main>
 
-  <footer class="site-footer">
-    <div class="footer-inner">
-      <div class="footer-brand">
-        <h3><i class="fas fa-leaf"></i> AgriTech</h3>
-        <p>Empowering India's Farming Future with innovative technology solutions that connect every stakeholder in the agricultural ecosystem.</p>
-        <div class="social-media">
-          <a href="#" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
-          <a href="#" aria-label="GitHub"><i class="fab fa-github"></i></a>
-          <a href="#" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
-        </div>
-      </div>
-      
-      <div class="footer-links">
-        <h4>Quick Links</h4>
-        <ul>
-          <li><a href="../index.html"><i class="fas fa-home"></i> Home</a></li>
-          <li><a href="../main.html"><i class="fas fa-tachometer-alt"></i> Dashboard</a></li>
-          <li><a href="../chat.html"><i class="fas fa-robot"></i> AI Assistant</a></li>
-          <li><a href="../feed-back.html"><i class="fas fa-comment"></i> Feedback</a></li>
-        </ul>
-      </div>
-      
-      <div class="footer-links">
-        <h4>Legal</h4>
-        <ul>
-          <li><a href="../terms-and-service.html"><i class="fas fa-file-contract"></i> Terms of Service</a></li>
-          <li><a href="../privacy-policy.html"><i class="fas fa-user-shield"></i> Privacy Policy</a></li>
-        </ul>
-      </div>
-    </div>
-    <div class="footer-bottom">
-      &copy; 2026 AgriTech. All rights reserved.
-    </div>
-  </footer>
-  <!-- Cursor Trail -->
-<div class="circle-container" id="cursorTrail"></div>
   <script src="forum.js"></script>
-  
   <script>
-    const toggle = document.getElementById('themeToggle');
-    const icon = toggle.querySelector('i');
-    
-    // Check saved theme
-    if(localStorage.getItem('theme') === 'dark') {
-      document.body.setAttribute('data-theme', 'dark');
-      icon.classList.remove('fa-moon');
-      icon.classList.add('fa-sun');
+    const themeToggle = document.getElementById('themeToggle');
+    const themeIcon = themeToggle.querySelector('i');
+
+    function syncThemeIcon() {
+      const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+      themeIcon.classList.toggle('fa-moon', !isDark);
+      themeIcon.classList.toggle('fa-sun', isDark);
+      themeToggle.setAttribute('aria-label', isDark ? 'Switch to light theme' : 'Switch to dark theme');
     }
 
-    toggle.addEventListener('click', () => {
-      const isDark = document.body.getAttribute('data-theme') === 'dark';
-      if(isDark) {
-        document.body.removeAttribute('data-theme');
-        localStorage.setItem('theme', 'light');
-        icon.classList.remove('fa-sun');
-        icon.classList.add('fa-moon');
-      } else {
-        document.body.setAttribute('data-theme', 'dark');
-        localStorage.setItem('theme', 'dark');
-        icon.classList.remove('fa-moon');
-        icon.classList.add('fa-sun');
-      }
+    syncThemeIcon();
+
+    themeToggle.addEventListener('click', () => {
+      const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+      document.documentElement.setAttribute('data-theme', isDark ? 'light' : 'dark');
+      localStorage.setItem('theme', isDark ? 'light' : 'dark');
+      syncThemeIcon();
     });
-                // --- Cursor Trailing Effect ---
-const container = document.getElementById('cursorTrail');
-const circleCount = 12;
-const circles = [];
-
-let mouseX = 0;
-let mouseY = 0;
-
-// Create circles
-for (let i = 0; i < circleCount; i++) {
-    const circle = document.createElement('div');
-    circle.classList.add('cursor-circle');
-    container.appendChild(circle);
-    circles.push({ el: circle, x: 0, y: 0 });
-}
-
-// Mouse move
-document.addEventListener('mousemove', (e) => {
-    mouseX = e.clientX;
-    mouseY = e.clientY;
-});
-
-// Click effects
-document.addEventListener('mousedown', () => {
-    circles.forEach(c => c.el.classList.add('cursor-clicking'));
-});
-document.addEventListener('mouseup', () => {
-    circles.forEach(c => c.el.classList.remove('cursor-clicking'));
-});
-
-// Hover effects on interactive elements
-document.addEventListener('mouseover', (e) => {
-    if (e.target.closest('a, button, .cta-button, .service-card, .shipment-card')) {
-        circles.forEach(c => c.el.classList.add('cursor-hovering'));
-    }
-});
-document.addEventListener('mouseout', (e) => {
-    if (e.target.closest('a, button, .cta-button, .service-card, .shipment-card')) {
-        circles.forEach(c => c.el.classList.remove('cursor-hovering'));
-    }
-});
-
-// Animate trailing effect
-function animateCursor() {
-    let x = mouseX;
-    let y = mouseY;
-
-    circles.forEach((circle) => {
-        circle.x += (x - circle.x) * 0.25;
-        circle.y += (y - circle.y) * 0.25;
-
-        circle.el.style.left = circle.x + 'px';
-        circle.el.style.top = circle.y + 'px';
-
-        x = circle.x;
-        y = circle.y;
-    });
-
-    requestAnimationFrame(animateCursor);
-}
-animateCursor();
   </script>
 </body>
 </html>

--- a/Forum/forum.js
+++ b/Forum/forum.js
@@ -43,16 +43,17 @@ document.getElementById('forumForm').addEventListener('submit', function (e) {
 
 function loadPosts() {
   const container = document.getElementById('forumPosts');
+  if (!container) return;
   
   fetch('http://localhost:5000/forum')
     .then(res => res.json())
     .then(posts => {
-      container.innerHTML = '';
+      container.innerHTML = '<div class="empty-state-card"><i class="fas fa-spinner fa-spin"></i><p>Loading discussions...</p></div>';
       
       if (posts.length === 0) {
         container.innerHTML = `
-          <div style="text-align: center; padding: 2rem; color: #64748b; background: white; border-radius: 12px; border: 1px dashed #cbd5e1;">
-            <i class="fas fa-comments" style="font-size: 2rem; margin-bottom: 1rem; color: #cbd5e1;"></i>
+          <div class="empty-state-card">
+            <i class="fas fa-comments"></i>
             <p>No discussions yet. Be the first to start one!</p>
           </div>`;
         return;

--- a/about.css
+++ b/about.css
@@ -590,7 +590,6 @@ html[data-theme="dark"] .footer {
     padding: 0.5rem 1rem;
     font-size: 0.85rem;
   }
-    min-width: -webkit-fill-available;
 
   .theme-label {
     min-width: 35px;

--- a/about.css
+++ b/about.css
@@ -123,7 +123,6 @@ html[data-theme="dark"] body {
   cursor: pointer;
   transition: all 0.3s ease;
   white-space: nowrap;
-  min-width: fit-content;
 }
 
 .theme-toggle:hover {
@@ -347,12 +346,13 @@ html[data-theme="dark"] .hero-subtitle {
 /* Content Section */
 .content-section {
   display: grid;
-  gap: 2rem;
+  gap: 1.5rem;
   margin-top: 2rem;
-  background: white;
+  padding: 0.25rem;
+  background: transparent;
 }
 html[data-theme="dark"] .content-section {
-  background: var(--bg-dark);
+  background: transparent;
 }
 
 
@@ -396,6 +396,85 @@ html[data-theme="dark"] .card h2 {
   color: var(--text-light);
   line-height: 1.8;
   margin-bottom: 1rem;
+}
+
+.why-matters-card {
+  border-left: 4px solid var(--secondary-color);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(245, 250, 246, 0.98));
+}
+
+html[data-theme="dark"] .why-matters-card {
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.98), rgba(15, 23, 42, 0.98));
+}
+
+.section-heading {
+  display: grid;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.section-eyebrow {
+  color: var(--secondary-color);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.section-intro {
+  max-width: 68ch;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.8;
+}
+
+.why-matters-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.why-point {
+  padding: 1.25rem;
+  border-radius: 16px;
+  background: rgba(22, 163, 74, 0.06);
+  border: 1px solid rgba(22, 163, 74, 0.1);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+html[data-theme="dark"] .why-point {
+  background: rgba(74, 222, 128, 0.08);
+  border-color: rgba(148, 163, 184, 0.14);
+}
+
+.why-point:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.12);
+}
+
+.why-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--secondary-color);
+  color: #ffffff;
+  margin-bottom: 0.9rem;
+}
+
+.why-point h3 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--primary-color);
+  margin-bottom: 0.5rem;
+}
+
+.why-point p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.75;
 }
 
 html[data-theme="dark"] .card p {
@@ -502,11 +581,16 @@ html[data-theme="dark"] .footer {
     font-size: 1.3rem;
   }
 
+  .why-matters-grid {
+    grid-template-columns: 1fr;
+  }
+
   .theme-toggle,
   .back-btn {
     padding: 0.5rem 1rem;
     font-size: 0.85rem;
   }
+    min-width: -webkit-fill-available;
 
   .theme-label {
     min-width: 35px;

--- a/about.html
+++ b/about.html
@@ -299,11 +299,11 @@
       display: none;
     }
 
-    /* Scroll To Top Button */
-    .scroll-top-btn {
+    /* Back To Top Button */
+    .back-to-top-btn {
         position: fixed;
-        bottom: 25px;
-        right: 25px;
+      bottom: 30px;
+      right: 30px;
         width: 52px;
         height: 52px;
         border-radius: 50%;
@@ -323,13 +323,13 @@
         z-index: 9999;
     }
 
-    .scroll-top-btn.show {
+      .back-to-top-btn.show {
         opacity: 1;
         visibility: visible;
         transform: translateY(0);
     }
 
-    .scroll-top-btn:hover {
+      .back-to-top-btn:hover {
         background: #27ae60;
         transform: scale(1.1);
     }
@@ -508,27 +508,27 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById("current-year").textContent =
     new Date().getFullYear();
 </script>
-<button id="scrollTopBtn" class="scroll-top-btn" aria-label="Scroll to top">
+<button id="backToTopBtn" class="back-to-top-btn" aria-label="Back to top">
     <i class="fas fa-arrow-up"></i>
 </button>
 <script>
 document.addEventListener("DOMContentLoaded", function () {
-    const scrollTopBtn = document.getElementById("scrollTopBtn");
+  const backToTopBtn = document.getElementById("backToTopBtn");
 
-    if (!scrollTopBtn) return;
+  if (!backToTopBtn) return;
 
     // Monitor Scroll Position
     window.addEventListener("scroll", function () {
         // Show button after scrolling down 300px
         if (window.pageYOffset > 300) {
-            scrollTopBtn.classList.add("show");
+      backToTopBtn.classList.add("show");
         } else {
-            scrollTopBtn.classList.remove("show");
+      backToTopBtn.classList.remove("show");
         }
     });
 
     // Scroll to top on click
-    scrollTopBtn.addEventListener("click", function () {
+  backToTopBtn.addEventListener("click", function () {
         window.scrollTo({
             top: 0,
             behavior: "smooth"

--- a/about.html
+++ b/about.html
@@ -40,6 +40,36 @@
                 </p>
             </div>
 
+                <section class="card why-matters-card" aria-labelledby="why-it-matters-title">
+                  <div class="section-heading">
+                    <p class="section-eyebrow">Why It Matters</p>
+                    <h2 id="why-it-matters-title">Technology should be practical, clear, and trustworthy</h2>
+                    <p class="section-intro">
+                      Better farming decisions depend on information that is easy to read, easy to scan, and simple to act on.
+                    </p>
+                  </div>
+
+                  <div class="why-matters-grid">
+                    <article class="why-point">
+                      <span class="why-icon"><i class="fa-solid fa-eye"></i></span>
+                      <h3>Readable guidance</h3>
+                      <p>Clear contrast and consistent spacing help farmers quickly understand the most important information.</p>
+                    </article>
+
+                    <article class="why-point">
+                      <span class="why-icon"><i class="fa-solid fa-layer-group"></i></span>
+                      <h3>Better structure</h3>
+                      <p>Well-aligned sections make the page feel dependable and reduce the effort needed to find key details.</p>
+                    </article>
+
+                    <article class="why-point">
+                      <span class="why-icon"><i class="fa-solid fa-seedling"></i></span>
+                      <h3>More trust</h3>
+                      <p>A polished layout reinforces that the platform is carefully maintained and built for real-world use.</p>
+                    </article>
+                  </div>
+                </section>
+
             <div class="card">
                 <h2>✨ Key Features</h2>
                 <ul class="features-list">
@@ -75,7 +105,7 @@
                 </p>
                 <p>
                     You can also connect with us on GitHub at 
-                    <a href="https://github.com/omroy07/AgriTech" target="_blank" class="link">omroy07/AgriTech</a>
+                    <a href="https://github.com/omroy07/AgriTech" target="_blank" rel="noopener" class="link">omroy07/AgriTech</a>
                 </p>
             </div>
 

--- a/career.html
+++ b/career.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="refresh" content="0; url=careers.html" />
+  <meta http-equiv="refresh" content="0; url=carrers.html" />
   <title>Careers | AgriTech</title>
   <script>
-    window.location.replace('careers.html');
+    window.location.replace('carrers.html');
   </script>
 </head>
 <body>

--- a/carrer.css
+++ b/carrer.css
@@ -1,442 +1,637 @@
-@import url('theme.css');/* Import Google Fonts - Same as mission page */
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&family=Libertinus+Serif:wght@400;700&display=swap');
+@import url('theme.css');
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700;800&family=Libertinus+Serif:wght@400;600;700&display=swap');
+
 :root {
-    /* LIGHT MODE: DARK TEXT ON LIGHT BG */
-    --bg-primary: #ffffff;
-    --bg-hero: #f0fdf4;
-    --text-primary: #1e293b;   /* Deep slate - clearly visible */
-    --text-secondary: #475569; /* Medium slate */
-    --card-bg: #ffffff;
-    --border-color: #e2e8f0;
-    --primary-green: #15803d;  /* Darker green for better contrast */
-    --nav-bg: #ffffff;
-    --accent-blue: #3b82f6;
-    --accent-orange: #f97316;
-    --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.05);
-    --shadow-md: 0 10px 30px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 20px 40px rgba(0, 0, 0, 0.1);
+  --bg-primary: #f3f7f4;
+  --bg-hero: #edf7ef;
+  --surface: rgba(255, 255, 255, 0.84);
+  --surface-strong: #ffffff;
+  --text-primary: #142033;
+  --text-secondary: #516072;
+  --border-color: rgba(20, 32, 51, 0.08);
+  --primary-green: #15803d;
+  --primary-green-strong: #0f6b32;
+  --shadow-sm: 0 4px 12px rgba(15, 23, 42, 0.06);
+  --shadow-md: 0 14px 34px rgba(15, 23, 42, 0.08);
+  --shadow-lg: 0 24px 48px rgba(15, 23, 42, 0.12);
+  --accent: #f59e0b;
 }
 
 [data-theme="dark"] {
-    /* DARK MODE: LIGHT TEXT ON DARK BG */
-    --bg-primary: #0f172a;
-    --bg-hero: #0f172a;
-    --text-primary: #f8fafc;   /* Off-white - clearly visible */
-    --text-secondary: #cbd5e1; /* Light gray */
-    --card-bg: #1e293b;
-    --border-color: #334155;
-    --nav-bg: #0f172a;
-    --primary-green: #4ade80;  /* Brighter green for dark background */
-    --accent-blue: #60a5fa;
-    --accent-orange: #fdba74;
-    --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.2);
-    --shadow-md: 0 10px 30px rgba(0, 0, 0, 0.25);
-    --shadow-lg: 0 20px 40px rgba(0, 0, 0, 0.3);
+  --bg-primary: #0b1120;
+  --bg-hero: #111827;
+  --surface: rgba(17, 24, 39, 0.9);
+  --surface-strong: #111827;
+  --text-primary: #e5e7eb;
+  --text-secondary: #94a3b8;
+  --border-color: rgba(148, 163, 184, 0.16);
+  --primary-green: #4ade80;
+  --primary-green-strong: #22c55e;
+  --shadow-sm: 0 6px 16px rgba(0, 0, 0, 0.2);
+  --shadow-md: 0 16px 36px rgba(0, 0, 0, 0.26);
+  --shadow-lg: 0 28px 56px rgba(0, 0, 0, 0.32);
 }
 
-/* Reset and Base Styles */
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
 }
 
 body {
-    font-family: 'Open Sans', sans-serif;
-    background-color: var(--bg-primary);
-    color: var(--text-primary);
-    transition: all 0.3s ease;
-    line-height: 1.6;
+  font-family: 'Open Sans', sans-serif;
+  background:
+    radial-gradient(circle at top left, rgba(34, 197, 94, 0.12), transparent 26%),
+    radial-gradient(circle at top right, rgba(245, 158, 11, 0.08), transparent 24%),
+    linear-gradient(180deg, var(--bg-primary), var(--bg-primary));
+  color: var(--text-primary);
+  line-height: 1.6;
+  transition: background-color 0.35s ease, color 0.35s ease;
 }
 
-/* Main Career Section */
-.career-section {
-    padding: 5rem 10%;
-    background: linear-gradient(180deg, var(--bg-hero) 0%, var(--bg-primary) 100%);
-    min-height: 100vh;
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px), linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+  background-size: 36px 36px;
+  opacity: 0.12;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.25), transparent 70%);
 }
 
-.career-section h1 {
-    font-family: 'Libertinus Serif', serif;
-    color: var(--primary-green);
-    font-size: 3.5rem;
-    margin-bottom: 1.5rem;
-    text-align: center;
+main {
+  position: relative;
 }
 
-.career-section h1 i {
-    margin-right: 15px;
-    font-size: 3rem;
-    vertical-align: middle;
+.card,
+.job-card,
+.stat-item,
+.benefit-card,
+.apply-section,
+.career-hero {
+  background: var(--surface);
+  border: 1px solid var(--border-color);
+  border-radius: 24px;
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
 }
 
-.career-section > p {
-    font-size: 1.3rem;
-    color: var(--text-secondary);
-    text-align: center;
-    margin-bottom: 4rem;
-    max-width: 800px;
-    margin-left: auto;
-    margin-right: auto;
+.careers-page {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 1.5rem 0 4rem;
+  display: grid;
+  gap: 1.5rem;
 }
 
-/* Career Stats */
+.career-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.9fr);
+  gap: 1.25rem;
+  padding: 1.75rem;
+  background: linear-gradient(135deg, var(--surface), var(--surface-strong));
+}
+
+.career-hero-copy {
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+}
+
+.eyebrow {
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--primary-green);
+}
+
+.career-hero h1 {
+  font-family: 'Libertinus Serif', serif;
+  font-size: clamp(2.4rem, 4vw, 4.2rem);
+  line-height: 1.02;
+  color: var(--text-primary);
+  max-width: 12ch;
+}
+
+.career-hero p {
+  color: var(--text-secondary);
+  max-width: 60ch;
+  font-size: 1.02rem;
+}
+
+.career-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 0.35rem;
+}
+
+.btn {
+  min-height: 44px;
+  padding: 0.85rem 1.15rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  text-decoration: none;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+}
+
+.btn-primary {
+  color: #ffffff;
+  background: linear-gradient(135deg, var(--primary-green), var(--primary-green-strong));
+  box-shadow: 0 16px 28px rgba(21, 128, 61, 0.24);
+}
+
+.btn-primary:hover {
+  box-shadow: 0 18px 34px rgba(21, 128, 61, 0.32);
+}
+
+.btn-secondary {
+  color: var(--text-primary);
+  background: var(--surface-strong);
+  border-color: var(--border-color);
+  box-shadow: var(--shadow-sm);
+}
+
+.btn-secondary:hover {
+  border-color: var(--primary-green);
+}
+
+.career-hero-panel {
+  display: grid;
+  gap: 0.9rem;
+  align-content: start;
+}
+
+.hero-metric {
+  padding: 1.1rem 1.2rem;
+  border-radius: 20px;
+  background: linear-gradient(180deg, rgba(22, 163, 74, 0.12), rgba(22, 163, 74, 0.05));
+  border: 1px solid rgba(22, 163, 74, 0.16);
+}
+
+.hero-metric span {
+  display: block;
+  font-size: 1.9rem;
+  font-weight: 800;
+  color: var(--primary-green);
+  line-height: 1;
+}
+
+.hero-metric small {
+  color: var(--text-secondary);
+}
+
 .career-stats {
-    display: flex;
-    justify-content: center;
-    gap: 4rem;
-    margin-bottom: 5rem;
-    flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
 }
 
 .stat-item {
-    background: var(--card-bg);
-    border: 1px solid var(--border-color);
-    border-radius: 20px;
-    padding: 2.5rem 3rem;
-    box-shadow: var(--shadow-md);
-    text-align: center;
-    min-width: 200px;
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+  padding: 1.5rem;
+  text-align: center;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.stat-item:hover {
-    transform: translateY(-5px);
-    box-shadow: var(--shadow-lg);
+.stat-item:hover,
+.job-card:hover,
+.benefit-card:hover,
+.apply-step:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-lg);
 }
 
 .stat-number {
-    color: var(--primary-green);
-    font-size: 3.5rem;
-    font-weight: 800;
-    display: block;
-    line-height: 1;
-    margin-bottom: 0.5rem;
+  display: block;
+  font-size: clamp(2rem, 3vw, 3rem);
+  font-weight: 800;
+  color: var(--primary-green);
+  line-height: 1;
 }
 
 .stat-label {
-    color: var(--text-secondary);
-    font-weight: 700;
-    font-size: 1.2rem;
-    display: block;
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--text-secondary);
+  font-weight: 700;
 }
 
-/* Job Openings Section */
-.job-openings {
-    max-width: 1200px;
-    margin: 0 auto;
+.job-openings,
+.benefits-section,
+.apply-section {
+  padding: 1.5rem;
 }
 
-.job-openings h2 {
-    font-family: 'Libertinus Serif', serif;
-    font-size: 2.5rem;
-    color: var(--primary-green);
-    margin-bottom: 2.5rem;
-    text-align: center;
-    position: relative;
-    padding-bottom: 1rem;
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.35rem;
 }
 
-.job-openings h2::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 100px;
-    height: 4px;
-    background-color: var(--primary-green);
-    border-radius: 2px;
+.section-heading.centered {
+  justify-content: center;
+  text-align: center;
 }
 
-.job-list {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-    gap: 2rem;
-    margin-bottom: 4rem;
+.section-heading h2,
+.benefits-section h2,
+.apply-section h2 {
+  font-family: 'Libertinus Serif', serif;
+  font-size: clamp(1.7rem, 3vw, 2.5rem);
+  color: var(--text-primary);
+  margin-top: 0.15rem;
 }
 
-.job-card {
-    background: var(--card-bg);
-    border: 1px solid var(--border-color);
-    border-radius: 20px;
-    padding: 2.5rem;
-    box-shadow: var(--shadow-sm);
-    transition: all 0.3s ease;
-    position: relative;
-    overflow: hidden;
+.section-heading p:last-child,
+.jobs-subtitle,
+.benefits-section p,
+.apply-section p {
+  color: var(--text-secondary);
 }
 
-.job-card:hover {
-    transform: translateY(-5px);
-    box-shadow: var(--shadow-md);
-    border-color: var(--primary-green);
+.jobs-controls {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
-.job-card::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 5px;
-    height: 100%;
-    background-color: var(--primary-green);
-    border-radius: 5px 0 0 5px;
+.search-box,
+.department-filter {
+  min-height: 44px;
+  border-radius: 14px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-strong);
+  box-shadow: var(--shadow-sm);
 }
 
-.job-card h3 {
-    font-size: 1.5rem;
-    color: var(--text-primary);
-    margin-bottom: 1rem;
-    font-weight: 700;
+.search-box {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0 0.95rem;
 }
 
-.job-department {
-    display: inline-block;
-    background-color: rgba(21, 128, 61, 0.1);
-    color: var(--primary-green);
-    padding: 0.4rem 1rem;
-    border-radius: 20px;
-    font-size: 0.9rem;
-    font-weight: 600;
-    margin-bottom: 1.5rem;
+.search-box i {
+  color: var(--text-secondary);
 }
 
-[data-theme="dark"] .job-department {
-    background-color: rgba(74, 222, 128, 0.15);
+.search-box input {
+  width: min(240px, 60vw);
+  min-height: 44px;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: var(--text-primary);
+}
+
+.department-filter-wrap {
+  display: inline-flex;
+}
+
+.department-filter {
+  padding: 0 0.95rem;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.job-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.modern-card {
+  padding: 1.35rem;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.modern-card::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: linear-gradient(180deg, var(--primary-green), rgba(245, 158, 11, 0.9));
+}
+
+.job-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.job-top h3,
+.benefit-card h3,
+.step-content h3 {
+  font-size: 1.2rem;
+  color: var(--text-primary);
+  margin-bottom: 0.35rem;
+}
+
+.job-badge,
+.job-type {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.76rem;
+  font-weight: 800;
+}
+
+.job-badge {
+  background: rgba(21, 128, 61, 0.12);
+  color: var(--primary-green);
+}
+
+.job-type {
+  background: rgba(148, 163, 184, 0.14);
+  color: var(--text-secondary);
+  white-space: nowrap;
 }
 
 .job-description {
-    color: var(--text-secondary);
-    margin-bottom: 1.5rem;
-    line-height: 1.6;
+  color: var(--text-secondary);
+  margin-bottom: 1rem;
 }
 
-.job-details {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-    margin-bottom: 1.5rem;
+.job-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem 1.2rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
 }
 
-.job-detail {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    color: var(--text-secondary);
-    font-size: 0.9rem;
+.job-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
 }
 
-.job-detail i {
-    color: var(--primary-green);
+.job-footer {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
+.btn-view-details,
 .btn-apply {
-    display: inline-block;
-    background-color: var(--primary-green);
-    color: white;
-    padding: 0.8rem 2rem;
-    border-radius: 10px;
-    text-decoration: none;
-    font-weight: 600;
-    text-align: center;
-    transition: all 0.3s ease;
-    border: none;
-    cursor: pointer;
-    width: 100%;
-    margin-top: 1rem;
-}
-
-.btn-apply:hover {
-    background-color: var(--text-primary);
-    transform: translateY(-2px);
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
-}
-
-/* Benefits Section */
-.benefits-section {
-    max-width: 1200px;
-    margin: 5rem auto;
-    padding: 3rem 0;
-}
-
-.benefits-section h2 {
-    font-family: 'Libertinus Serif', serif;
-    font-size: 2.5rem;
-    color: var(--primary-green);
-    margin-bottom: 3rem;
-    text-align: center;
+  flex: 1 1 140px;
 }
 
 .benefits-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-    gap: 2rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
 }
 
 .benefit-card {
-    background: var(--card-bg);
-    border: 1px solid var(--border-color);
-    border-radius: 20px;
-    padding: 2rem;
-    text-align: center;
-    transition: all 0.3s ease;
-    box-shadow: var(--shadow-sm);
-}
-
-.benefit-card:hover {
-    transform: translateY(-5px);
-    box-shadow: var(--shadow-md);
+  padding: 1.4rem;
+  text-align: center;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .benefit-icon {
-    font-size: 2.5rem;
-    color: var(--primary-green);
-    margin-bottom: 1.5rem;
-    display: block;
-}
-
-.benefit-card h3 {
-    font-size: 1.3rem;
-    color: var(--text-primary);
-    margin-bottom: 1rem;
-    font-weight: 700;
+  font-size: 2rem;
+  color: var(--primary-green);
+  margin-bottom: 1rem;
 }
 
 .benefit-card p {
-    color: var(--text-secondary);
-    font-size: 0.95rem;
-    line-height: 1.6;
-}
-
-/* How to Apply Section */
-.apply-section {
-    max-width: 800px;
-    margin: 4rem auto;
-    padding: 3rem;
-    background: var(--card-bg);
-    border: 1px solid var(--border-color);
-    border-radius: 20px;
-    box-shadow: var(--shadow-md);
-}
-
-.apply-section h2 {
-    font-family: 'Libertinus Serif', serif;
-    font-size: 2.5rem;
-    color: var(--primary-green);
-    margin-bottom: 2rem;
-    text-align: center;
+  color: var(--text-secondary);
 }
 
 .apply-steps {
-    display: flex;
-    flex-direction: column;
-    gap: 2.5rem;
-    margin-bottom: 3rem;
+  display: grid;
+  gap: 1rem;
 }
 
 .apply-step {
-    display: flex;
-    align-items: flex-start;
-    gap: 1.5rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.1rem 1.25rem;
+  border-radius: 20px;
+  background: var(--surface-strong);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .step-number {
-    background-color: var(--primary-green);
-    color: white;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-weight: 700;
-    font-size: 1.2rem;
-    flex-shrink: 0;
-}
-
-.step-content h3 {
-    font-size: 1.3rem;
-    color: var(--text-primary);
-    margin-bottom: 0.5rem;
-    font-weight: 700;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+  color: #ffffff;
+  background: linear-gradient(135deg, var(--primary-green), var(--primary-green-strong));
 }
 
 .step-content p {
-    color: var(--text-secondary);
-    line-height: 1.6;
+  color: var(--text-secondary);
 }
 
-.apply-cta {
-    text-align: center;
-    margin-top: 3rem;
+.site-footer {
+  background: linear-gradient(135deg, #14532d, #166534);
+  color: #ffffff;
+  margin-top: 1rem;
+  padding: 2rem 1.25rem 1.25rem;
 }
 
-.cta-text {
-    font-size: 1.2rem;
-    color: var(--text-secondary);
-    margin-bottom: 2rem;
+.site-footer .footer-inner {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
 }
 
-/* Responsive Design */
-@media (max-width: 992px) {
-    .career-section {
-        padding: 4rem 5%;
-    }
-    
-    .career-section h1 {
-        font-size: 3rem;
-    }
-    
-    .job-list {
-        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    }
+.footer-brand {
+  display: grid;
+  gap: 0.6rem;
 }
 
-@media (max-width: 768px) {
-    .career-section h1 {
-        font-size: 2.5rem;
-    }
-    
-    .career-stats {
-        gap: 2rem;
-    }
-    
-    .stat-item {
-        padding: 2rem;
-        min-width: 170px;
-    }
-    
-    .benefits-grid {
-        grid-template-columns: 1fr;
-    }
-    
-    .apply-section {
-        padding: 2rem;
-    }
+.footer-logo {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  object-fit: cover;
+  background: #ffffff;
+  padding: 4px;
 }
 
-@media (max-width: 576px) {
-    .career-section {
-        padding: 3rem 1.5rem;
-    }
-    
-    .career-section h1 {
-        font-size: 2.2rem;
-    }
-    
-    .career-stats {
-        flex-direction: column;
-        align-items: center;
-    }
-    
-    .job-list {
-        grid-template-columns: 1fr;
-    }
-    
-    .apply-step {
-        flex-direction: column;
-        align-items: center;
-        text-align: center;
-    }
+.site-footer h3,
+.site-footer h4 {
+  margin-bottom: 0.4rem;
+}
+
+.site-footer p {
+  opacity: 0.9;
+}
+
+.site-footer ul {
+  list-style: none;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.site-footer a {
+  color: #ffffff;
+  opacity: 0.92;
+  text-decoration: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.site-footer a:hover {
+  opacity: 1;
+  transform: translateX(3px);
+}
+
+.social-media {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.social-media a {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.footer-bottom {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 1rem auto 0;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.18);
+  text-align: center;
+  opacity: 0.9;
+}
+
+.scroll-top-btn {
+  position: fixed;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  width: 52px;
+  height: 52px;
+  border: 0;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--primary-green), var(--primary-green-strong));
+  color: #ffffff;
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.22);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(10px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  z-index: 999;
+}
+
+.scroll-top-btn.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.scroll-top-btn:hover {
+  transform: translateY(-2px) scale(1.04);
+  box-shadow: 0 20px 32px rgba(15, 23, 42, 0.28);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 900px) {
+  .career-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .career-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .section-heading {
+    flex-direction: column;
+  }
+
+  .jobs-controls {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .careers-page {
+    width: min(100%, calc(100% - 1rem));
+    padding-top: 1rem;
+  }
+
+  .career-hero,
+  .job-openings,
+  .benefits-section,
+  .apply-section {
+    padding: 1.15rem;
+  }
+
+  .career-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .job-footer {
+    flex-direction: column;
+  }
+
+  .btn-view-details,
+  .btn-apply {
+    width: 100%;
+    flex-basis: auto;
+  }
+
+  .search-box input {
+    width: 100%;
+  }
 }

--- a/carrers.html
+++ b/carrers.html
@@ -1,677 +1,356 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Careers | AgriTech</title>
-    <!-- Link the career CSS -->
-    <link rel="stylesheet" href="carrer.css">
-    <!-- Font Awesome CDN for icons -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Explore careers at AgriTech and join a team building the future of agriculture." />
+  <title>Careers | AgriTech</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700;800&family=Libertinus+Serif:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
+  <link rel="stylesheet" href="carrer.css" />
+
+  <script>
+    (function () {
+      const savedTheme = localStorage.getItem('theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      document.documentElement.setAttribute('data-theme', savedTheme || (prefersDark ? 'dark' : 'light'));
+    })();
+  </script>
 </head>
 <body>
-    <div w3-include-html="navbar.html"></div>
+  <div w3-include-html="navbar.html"></div>
 
-    <main>
-        <section class="career-section">
-            <h1><i class="fa-solid fa-briefcase"></i> Careers</h1>
-            <p>Join us in building the future of agriculture. We're looking for passionate individuals to help transform farming through technology.</p>
+  <main class="careers-page">
+    <section class="career-hero card">
+      <div class="career-hero-copy">
+        <p class="eyebrow">Grow with AgriTech</p>
+        <h1>Careers that shape the future of farming</h1>
+        <p>
+          Join a team that blends agriculture, design, and technology to build tools farmers actually trust and use.
+        </p>
 
-            <!-- Career Stats -->
-            <div class="career-stats">
-                <div class="stat-item">
-                    <span class="stat-number">10+</span>
-                    <span class="stat-label">Open Positions</span>
-                </div>
-                <div class="stat-item">
-                    <span class="stat-number">5</span>
-                    <span class="stat-label">Departments</span>
-                </div>
-                <div class="stat-item">
-                    <span class="stat-number">100%</span>
-                    <span class="stat-label">Remote Friendly</span>
-                </div>
-            </div>
-
-            <!-- 🌿 Modern Job Openings Section (Enhanced UI + Search + Filter + Modal Ready) -->
-<div class="job-openings modern-jobs">
-    <div class="jobs-header">
-        <div class="jobs-title">
-            <h2><i class="fa-solid fa-briefcase"></i> Current Openings</h2>
-            <p class="jobs-subtitle">Discover roles where technology meets agriculture 🚜</p>
-        </div>
-
-        <!-- Search & Filter Controls -->
-        <div class="jobs-controls">
-            <div class="search-box">
-                <i class="fa-solid fa-magnifying-glass"></i>
-                <input 
-                    type="text" 
-                    id="jobSearch" 
-                    placeholder="Search by role, keyword..."
-                />
-            </div>
-
-            <select id="jobFilter" class="department-filter">
-                <option value="all">All Departments</option>
-                <option value="Research & Development">Research & Development</option>
-                <option value="Engineering">Engineering</option>
-                <option value="Analytics">Analytics</option>
-            </select>
-        </div>
-    </div>
-
-    <!-- Job Grid -->
-    <div class="job-grid" id="jobList">
-
-        <!-- Job 1 -->
-        <div class="job-card modern-card"
-             data-title="Senior Agronomist"
-             data-department="Research & Development">
-             
-            <div class="job-top">
-                <div>
-                    <h3>Senior Agronomist</h3>
-                    <span class="job-badge r&d">Research & Development</span>
-                </div>
-                <span class="job-type">Full-time</span>
-            </div>
-
-            <p class="job-description">
-                Lead research initiatives to improve crop yield through data-driven insights and innovative farming techniques.
-            </p>
-
-            <div class="job-meta">
-                <span><i class="fa-solid fa-location-dot"></i> Remote</span>
-                <span><i class="fa-solid fa-calendar"></i> Posted 2 days ago</span>
-            </div>
-
-            <div class="job-footer">
-                <button class="btn-view-details">View Details</button>
-                <button class="btn-apply">Apply Now</button>
-            </div>
-        </div>
-
-        <!-- Job 2 -->
-        <div class="job-card modern-card"
-             data-title="Full Stack Developer"
-             data-department="Engineering">
-
-            <div class="job-top">
-                <div>
-                    <h3>Full Stack Developer</h3>
-                    <span class="job-badge eng">Engineering</span>
-                </div>
-                <span class="job-type">Full-time</span>
-            </div>
-
-            <p class="job-description">
-                Build scalable applications for farm management, data analytics, and IoT integration in agriculture.
-            </p>
-
-            <div class="job-meta">
-                <span><i class="fa-solid fa-location-dot"></i> Remote / Hybrid</span>
-                <span><i class="fa-solid fa-calendar"></i> Posted 1 week ago</span>
-            </div>
-
-            <div class="job-footer">
-                <button class="btn-view-details">View Details</button>
-                <button class="btn-apply">Apply Now</button>
-            </div>
-        </div>
-
-        <!-- Job 3 -->
-        <div class="job-card modern-card"
-             data-title="Data Scientist"
-             data-department="Analytics">
-
-            <div class="job-top">
-                <div>
-                    <h3>Data Scientist</h3>
-                    <span class="job-badge analytics">Analytics</span>
-                </div>
-                <span class="job-type">Full-time</span>
-            </div>
-
-            <p class="job-description">
-                Develop predictive models for crop disease, weather patterns, and soil health using machine learning.
-            </p>
-
-            <div class="job-meta">
-                <span><i class="fa-solid fa-location-dot"></i> Remote</span>
-                <span><i class="fa-solid fa-calendar"></i> Posted 3 days ago</span>
-            </div>
-
-            <div class="job-footer">
-                <button class="btn-view-details">View Details</button>
-                <button class="btn-apply">Apply Now</button>
-            </div>
-        </div>
-
-    </div>
-</div>
-
-            <!-- Benefits Section -->
-            <div class="benefits-section">
-                <h2>Why Join AgriTech?</h2>
-                <div class="benefits-grid">
-                    <div class="benefit-card">
-                        <i class="fa-solid fa-hand-holding-heart benefit-icon"></i>
-                        <h3>Comprehensive Benefits</h3>
-                        <p>Health, dental, vision insurance, 401k matching, and generous parental leave policies.</p>
-                    </div>
-                    <div class="benefit-card">
-                        <i class="fa-solid fa-globe benefit-icon"></i>
-                        <h3>Remote First</h3>
-                        <p>Work from anywhere with flexible hours. We prioritize results over location.</p>
-                    </div>
-                    <div class="benefit-card">
-                        <i class="fa-solid fa-graduation-cap benefit-icon"></i>
-                        <h3>Growth & Learning</h3>
-                        <p>Annual learning budget, conference allowances, and mentorship programs.</p>
-                    </div>
-                    <div class="benefit-card">
-                        <i class="fa-solid fa-seedling benefit-icon"></i>
-                        <h3>Make an Impact</h3>
-                        <p>Your work directly contributes to sustainable agriculture and food security.</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- How to Apply Section -->
-            <div class="apply-section">
-                <h2>How to Apply</h2>
-                <div class="apply-steps">
-                    <div class="apply-step">
-                        <div class="step-number">1</div>
-                        <div class="step-content">
-                            <h3>Find Your Role</h3>
-                            <p>Browse our open positions and find the one that matches your skills and passions.</p>
-                        </div>
-                    </div>
-                    <div class="apply-step">
-                        <div class="step-number">2</div>
-                        <div class="step-content">
-                            <h3>Submit Application</h3>
-                            <p>Click "Apply Now" and submit your resume and cover letter through our portal.</p>
-                        </div>
-                    </div>
-                    <div class="apply-step">
-                        <div class="step-number">3</div>
-                        <div class="step-content">
-                            <h3>Interview Process</h3>
-                            <p>If selected, you'll go through 2-3 rounds of interviews with our team members.</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-    </main>
-    
-    <style>
-      .site-footer {
-        background: linear-gradient(135deg, #2e7d32, #66bb6a);
-        color: #fff;
-        margin-top: auto;
-        padding: 2rem 1.25rem;
-      }
-      .site-footer .footer-inner {
-        max-width: 1200px;
-        margin: 0 auto;
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 1.5rem;
-        align-items: flex-start;
-      }
-      .footer-brand {
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-      }
-      .footer-logo {
-        width: 48px;
-        height: 48px;
-        border-radius: 8px;
-        object-fit: cover;
-        background: #fff;
-        padding: 4px;
-      }
-      .site-footer h3,
-      .site-footer h4 {
-        margin: 0 0 0.5rem 0;
-      }
-      .site-footer p {
-        margin: 0;
-        opacity: 0.9;
-      }
-      .site-footer ul {
-        list-style: none;
-        padding: 0;
-        margin: 0;
-        display: flex;
-        flex-direction: column;
-        gap: 0.4rem;
-      }
-      .site-footer a {
-        color: #fff;
-        text-decoration: none;
-        opacity: 0.9;
-        transition: opacity 0.2s;
-      }
-      .site-footer a:hover {
-        opacity: 1;
-        text-decoration: underline;
-      }
-      .footer-bottom {
-        max-width: 1200px;
-        margin: 1rem auto 0;
-        padding-top: 1rem;
-        border-top: 1px solid rgba(255, 255, 255, 0.25);
-        text-align: center;
-        font-size: 0.9rem;
-        opacity: 0.9;
-      }
-      .social-media {
-        display: flex;
-        gap: 1rem;
-        margin-top: 0.5rem;
-      }
-      .social-media a {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 40px;
-        height: 40px;
-        background: rgba(255, 255, 255, 0.1);
-        border-radius: 50%;
-        transition: all 0.3s ease;
-        font-size: 1.2rem;
-      }
-      .social-media a:hover {
-        background: rgba(255, 255, 255, 0.2);
-        transform: translateY(-2px);
-      }
-
-      /* ===== Modern Jobs Section ===== */
-.modern-jobs {
-    margin-top: 2rem;
-}
-
-.jobs-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 1rem;
-    margin-bottom: 1.5rem;
-}
-
-.jobs-subtitle {
-    color: #6b7280;
-    font-size: 0.95rem;
-}
-
-/* Search Box */
-.jobs-controls {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-}
-
-.search-box {
-    display: flex;
-    align-items: center;
-    background: #f4f6f5;
-    padding: 8px 12px;
-    border-radius: 10px;
-    border: 1px solid #e5e7eb;
-}
-
-.search-box input {
-    border: none;
-    outline: none;
-    background: transparent;
-    margin-left: 8px;
-    font-size: 0.9rem;
-    width: 200px;
-}
-
-.department-filter {
-    padding: 8px 12px;
-    border-radius: 10px;
-    border: 1px solid #e5e7eb;
-    background: #fff;
-    cursor: pointer;
-}
-
-/* Grid Layout */
-.job-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 20px;
-}
-
-/* Modern Card */
-.modern-card {
-    background: #ffffff;
-    border-radius: 16px;
-    padding: 20px;
-    border: 1px solid #e6f4ea;
-    box-shadow: 0 8px 24px rgba(0,0,0,0.05);
-    transition: all 0.3s ease;
-}
-
-.modern-card:hover {
-    transform: translateY(-6px);
-    box-shadow: 0 12px 30px rgba(46,125,50,0.15);
-}
-
-/* Top Section */
-.job-top {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.job-badge {
-    font-size: 0.75rem;
-    padding: 4px 10px;
-    border-radius: 999px;
-    background: #e8f5e9;
-    color: #2e7d32;
-    font-weight: 600;
-}
-
-.job-type {
-    font-size: 0.8rem;
-    background: #f1f5f9;
-    padding: 4px 10px;
-    border-radius: 8px;
-}
-
-/* Meta Info */
-.job-meta {
-    display: flex;
-    justify-content: space-between;
-    font-size: 0.85rem;
-    color: #6b7280;
-    margin-top: 10px;
-}
-
-/* Footer Buttons */
-.job-footer {
-    display: flex;
-    justify-content: space-between;
-    margin-top: 15px;
-}
-
-.btn-view-details {
-    background: transparent;
-    border: 2px solid #2e7d32;
-    color: #2e7d32;
-    padding: 6px 14px;
-    border-radius: 8px;
-    cursor: pointer;
-    transition: 0.3s;
-}
-
-.btn-view-details:hover {
-    background: #2e7d32;
-    color: white;
-}
-        
-      #scrollTopBtn {
-        position: fixed;
-        bottom: 25px;
-        right: 25px;
-        background: #2e7d32;
-        color: #fff;
-        border: none;
-        border-radius: 50%;
-        width: 50px;
-        height: 50px;
-        font-size: 1.2rem;
-        cursor: pointer;
-        display: none;
-        box-shadow: 0 6px 12px rgba(0,0,0,0.2);
-        transition: all 0.3s ease;
-        z-index: 999;
-      }
-      #scrollTopBtn:hover {
-        background: #1b5e20;
-        transform: translateY(-3px);
-      }
-    </style>
-    <footer class="site-footer">
-      <div class="footer-inner">
-        <div class="footer-brand">
-          <img src="images/logo.png" alt="AgriTech logo" class="footer-logo" />
-          <h3>AgriTech</h3>
-          <p>Empowering India's Farming Future</p>
-          <div class="social-media">
-            <a
-              href="https://instagram.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Follow us on Instagram"
-              ><i class="fab fa-instagram"></i
-            ></a>
-            <a
-              href="https://github.com/omroy07"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="View our GitHub repositories"
-              ><i class="fab fa-github"></i
-            ></a>
-            <a
-              href="https://www.linkedin.com/in/om-roy-3b809628a/"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Connect with us on LinkedIn"
-              ><i class="fab fa-linkedin"></i
-            ></a>
-          </div>
-        </div>
-        <div class="footer-links">
-          <h4>Quick Links</h4>
-          <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="main.html">Dashboard</a></li>
-            <li><a href="feed-back.html">Feedback</a></li>
-            <li><a href="chat.html">AI Assistant</a></li>
-          </ul>
-        </div>
-        <div class="footer-links">
-          <h4>Tools</h4>
-          <ul>
-            <li>
-              <a href="Crop Recommendation/index.html">Crop Recommendation</a>
-
-            </li>
-            <li>
-              <a href="Crop Yield Prediction/index.html">Yield Prediction</a>
-
-            </li>
-            <li>
-              <a href="Disease prediction/index.html">Disease Detector</a>
-
-            </li>
-            <li>
-              <a href="Crop_Planning/templates/cropplan.html">Crop Planner</a>
-            </li>
-          </ul>
+        <div class="career-actions">
+          <a href="index.html" class="btn btn-secondary">
+            <i class="fa-solid fa-house"></i>
+            Back to Home
+          </a>
+          <a href="#job-openings" class="btn btn-primary">
+            <i class="fa-solid fa-arrow-down"></i>
+            Explore Open Roles
+          </a>
         </div>
       </div>
-      <div class="footer-bottom">© <span id="current-year">2026</span> AgriTech • Made for farmers</div>
-    </footer>
 
-    <!-- Scroll to Top Button -->
-    <button id="scrollTopBtn" aria-label="Scroll to top">
-         <i class="fa-solid fa-arrow-up"></i>
-    </button>
+      <div class="career-hero-panel">
+        <div class="hero-metric">
+          <span>10+</span>
+          <small>Open positions</small>
+        </div>
+        <div class="hero-metric">
+          <span>5</span>
+          <small>Departments</small>
+        </div>
+        <div class="hero-metric">
+          <span>100%</span>
+          <small>Remote friendly</small>
+        </div>
+      </div>
+    </section>
 
-    <!-- Optional: Add theme toggle script if needed -->
-    <script>
-        // Theme toggle functionality
-        document.addEventListener('DOMContentLoaded', function() {
-            // Check for saved theme or default to light
-            const savedTheme = localStorage.getItem('theme') || 'light';
-            document.documentElement.setAttribute('data-theme', savedTheme === 'dark' ? 'dark' : 'light');
-            
-            // If you have a theme toggle button, you can add this:
-          const themeToggle = document.getElementById('themeToggle');
-          if (themeToggle) {
-            themeToggle.addEventListener('click', function() {
-              const currentTheme = document.documentElement.getAttribute('data-theme');
-              const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-              document.documentElement.setAttribute('data-theme', newTheme);
-              localStorage.setItem('theme', newTheme);
-            });
-          }
-        });
-    </script>
-    <script src="auth.js"></script>
-    <script>
-function applyTheme(theme) {
-    const html = document.documentElement;
-    html.setAttribute('data-theme', theme);
+    <section class="career-stats" aria-label="Career highlights">
+      <div class="stat-item card">
+        <span class="stat-number">10+</span>
+        <span class="stat-label">Open Positions</span>
+      </div>
+      <div class="stat-item card">
+        <span class="stat-number">5</span>
+        <span class="stat-label">Departments</span>
+      </div>
+      <div class="stat-item card">
+        <span class="stat-number">100%</span>
+        <span class="stat-label">Remote Friendly</span>
+      </div>
+    </section>
 
-    // Update labels/icons in navbar if present
-    const themeLabel = document.querySelector('.theme-label');
-    if (themeLabel) themeLabel.textContent = theme === 'light' ? 'Light' : 'Dark';
-}
+    <section class="job-openings card" id="job-openings">
+      <div class="section-heading">
+        <div>
+          <p class="eyebrow">Current Openings</p>
+          <h2>Discover roles where technology meets agriculture</h2>
+          <p>Filter by department or search by role to find the best fit for your next step.</p>
+        </div>
 
-function initThemeToggle() {
-    const themeToggle = document.getElementById('themeToggle');
-    if (!themeToggle) return; // navbar not loaded yet
+        <div class="jobs-controls">
+          <label class="search-box" aria-label="Search jobs">
+            <i class="fa-solid fa-magnifying-glass"></i>
+            <input type="text" id="jobSearch" placeholder="Search by role or keyword" />
+          </label>
 
-    themeToggle.addEventListener('click', () => {
-        const html = document.documentElement;
-        const current = html.getAttribute('data-theme');
-        const next = current === 'light' ? 'dark' : 'light';
-        applyTheme(next);
-        localStorage.setItem('agritech-theme', next);
-    });
-}
+          <label class="department-filter-wrap">
+            <span class="sr-only">Filter by department</span>
+            <select id="jobFilter" class="department-filter">
+              <option value="all">All Departments</option>
+              <option value="Research & Development">Research & Development</option>
+              <option value="Engineering">Engineering</option>
+              <option value="Analytics">Analytics</option>
+            </select>
+          </label>
+        </div>
+      </div>
 
+      <div class="job-grid" id="jobList">
+        <article class="job-card modern-card" data-title="Senior Agronomist" data-department="Research & Development">
+          <div class="job-top">
+            <div>
+              <h3>Senior Agronomist</h3>
+              <span class="job-badge">Research & Development</span>
+            </div>
+            <span class="job-type">Full-time</span>
+          </div>
 
-// Initialize theme from localStorage
-document.addEventListener('DOMContentLoaded', () => {
-    const savedTheme = localStorage.getItem('agritech-theme') || 'light';
-    applyTheme(savedTheme);
-});
+          <p class="job-description">
+            Lead research initiatives to improve crop yield through data-driven insights and innovative farming techniques.
+          </p>
 
-// Load navbar and attach toggle AFTER navbar is loaded
-function includeHTML() {
-    var z, i, elmnt, file, xhttp;
-    z = document.getElementsByTagName("*");
-    for (i = 0; i < z.length; i++) {
-        elmnt = z[i];
-        file = elmnt.getAttribute("w3-include-html");
-        if (file) {
-            xhttp = new XMLHttpRequest();
-            xhttp.onreadystatechange = function() {
-                if (this.readyState == 4) {
-                    if (this.status == 200) {elmnt.innerHTML = this.responseText;}
-                    if (this.status == 404) {elmnt.innerHTML = "Page not found.";}
-                    elmnt.removeAttribute("w3-include-html");
-                    includeHTML();
+          <div class="job-meta">
+            <span><i class="fa-solid fa-location-dot"></i> Remote</span>
+            <span><i class="fa-solid fa-calendar"></i> Posted 2 days ago</span>
+          </div>
 
-                    // ✅ Attach theme toggle AFTER navbar loads
-                    initThemeToggle();
-                }
-            }
-            xhttp.open("GET", file, true);
-            xhttp.send();
-            return;
-        }
-    }
-}
-includeHTML();
-</script>
-<!-- ===== Universal Back To Top Button (All Pages) ===== -->
-<style>
-  #globalBackToTop {
-    position: fixed;
-    bottom: 90px; /* prevents overlap with chatbot/floating icons */
-    right: 25px;
-    z-index: 9999;
-    display: none;
-    background: #2ecc71;
-    color: #ffffff;
-    border: none;
-    border-radius: 50%;
-    width: 52px;
-    height: 52px;
-    font-size: 22px;
-    font-weight: bold;
-    cursor: pointer;
-    box-shadow: 0 6px 16px rgba(0,0,0,0.25);
-    transition: opacity 0.3s ease, transform 0.2s ease;
-  }
+          <div class="job-footer">
+            <button class="btn btn-secondary btn-view-details" type="button">View Details</button>
+            <button class="btn btn-primary btn-apply" type="button">Apply Now</button>
+          </div>
+        </article>
 
-  #globalBackToTop:hover {
-    transform: scale(1.12);
-    background: #27ae60;
-  }
+        <article class="job-card modern-card" data-title="Full Stack Developer" data-department="Engineering">
+          <div class="job-top">
+            <div>
+              <h3>Full Stack Developer</h3>
+              <span class="job-badge">Engineering</span>
+            </div>
+            <span class="job-type">Full-time</span>
+          </div>
 
-  @media (max-width: 768px) {
-    #globalBackToTop {
-      bottom: 100px; /* better spacing on mobile */
-      right: 18px;
-      width: 48px;
-      height: 48px;
-      font-size: 20px;
-    }
-  }
-</style>
+          <p class="job-description">
+            Build scalable applications for farm management, data analytics, and IoT integration in agriculture.
+          </p>
 
-<button id="globalBackToTop" title="Back to Top">↑</button>
+          <div class="job-meta">
+            <span><i class="fa-solid fa-location-dot"></i> Remote / Hybrid</span>
+            <span><i class="fa-solid fa-calendar"></i> Posted 1 week ago</span>
+          </div>
 
-<script>
-  (function () {
-    const btn = document.getElementById("globalBackToTop");
+          <div class="job-footer">
+            <button class="btn btn-secondary btn-view-details" type="button">View Details</button>
+            <button class="btn btn-primary btn-apply" type="button">Apply Now</button>
+          </div>
+        </article>
 
-    // Show button after scrolling down
-    window.addEventListener("scroll", function () {
-      if (window.scrollY > 300) {
-        btn.style.display = "block";
-      } else {
-        btn.style.display = "none";
+        <article class="job-card modern-card" data-title="Data Scientist" data-department="Analytics">
+          <div class="job-top">
+            <div>
+              <h3>Data Scientist</h3>
+              <span class="job-badge">Analytics</span>
+            </div>
+            <span class="job-type">Full-time</span>
+          </div>
+
+          <p class="job-description">
+            Develop predictive models for crop disease, weather patterns, and soil health using machine learning.
+          </p>
+
+          <div class="job-meta">
+            <span><i class="fa-solid fa-location-dot"></i> Remote</span>
+            <span><i class="fa-solid fa-calendar"></i> Posted 3 days ago</span>
+          </div>
+
+          <div class="job-footer">
+            <button class="btn btn-secondary btn-view-details" type="button">View Details</button>
+            <button class="btn btn-primary btn-apply" type="button">Apply Now</button>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="benefits-section card">
+      <div class="section-heading centered">
+        <div>
+          <p class="eyebrow">Why Join AgriTech</p>
+          <h2>Build work that matters</h2>
+          <p>We combine flexibility, growth, and mission-driven work so people can do their best work.</p>
+        </div>
+      </div>
+
+      <div class="benefits-grid">
+        <article class="benefit-card">
+          <i class="fa-solid fa-hand-holding-heart benefit-icon"></i>
+          <h3>Comprehensive Benefits</h3>
+          <p>Health, dental, vision insurance, 401k matching, and generous parental leave policies.</p>
+        </article>
+        <article class="benefit-card">
+          <i class="fa-solid fa-globe benefit-icon"></i>
+          <h3>Remote First</h3>
+          <p>Work from anywhere with flexible hours. We prioritize outcomes over location.</p>
+        </article>
+        <article class="benefit-card">
+          <i class="fa-solid fa-graduation-cap benefit-icon"></i>
+          <h3>Growth & Learning</h3>
+          <p>Annual learning budget, conference allowances, and mentorship programs.</p>
+        </article>
+        <article class="benefit-card">
+          <i class="fa-solid fa-seedling benefit-icon"></i>
+          <h3>Make an Impact</h3>
+          <p>Your work directly contributes to sustainable agriculture and food security.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="apply-section card">
+      <div class="section-heading centered">
+        <div>
+          <p class="eyebrow">How to Apply</p>
+          <h2>A simple path to join the team</h2>
+        </div>
+      </div>
+
+      <div class="apply-steps">
+        <article class="apply-step">
+          <div class="step-number">1</div>
+          <div class="step-content">
+            <h3>Find Your Role</h3>
+            <p>Browse our open positions and find the one that matches your skills and passions.</p>
+          </div>
+        </article>
+        <article class="apply-step">
+          <div class="step-number">2</div>
+          <div class="step-content">
+            <h3>Submit Application</h3>
+            <p>Click Apply Now and submit your resume and cover letter through our portal.</p>
+          </div>
+        </article>
+        <article class="apply-step">
+          <div class="step-number">3</div>
+          <div class="step-content">
+            <h3>Interview Process</h3>
+            <p>If selected, you will go through 2 to 3 rounds of interviews with our team members.</p>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-brand">
+        <img src="images/logo.png" alt="AgriTech logo" class="footer-logo" />
+        <h3>AgriTech</h3>
+        <p>Empowering India's Farming Future with modern tools for farmers, teams, and partners.</p>
+        <div class="social-media">
+          <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Follow us on Instagram"><i class="fab fa-instagram"></i></a>
+          <a href="https://github.com/omroy07" target="_blank" rel="noopener noreferrer" aria-label="View our GitHub repositories"><i class="fab fa-github"></i></a>
+          <a href="https://www.linkedin.com/in/om-roy-3b809628a/" target="_blank" rel="noopener noreferrer" aria-label="Connect with us on LinkedIn"><i class="fab fa-linkedin"></i></a>
+        </div>
+      </div>
+      <div class="footer-links">
+        <h4>Quick Links</h4>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="main.html">Dashboard</a></li>
+          <li><a href="feed-back.html">Feedback</a></li>
+          <li><a href="chat.html">AI Assistant</a></li>
+        </ul>
+      </div>
+      <div class="footer-links">
+        <h4>Tools</h4>
+        <ul>
+          <li><a href="Crop Recommendation/index.html">Crop Recommendation</a></li>
+          <li><a href="Crop Yield Prediction/index.html">Yield Prediction</a></li>
+          <li><a href="Disease prediction/index.html">Disease Detector</a></li>
+          <li><a href="Crop_Planning/templates/cropplan.html">Crop Planner</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">&copy; <span id="current-year">2026</span> AgriTech &bull; Made for farmers</div>
+  </footer>
+
+  <button id="scrollTopBtn" class="scroll-top-btn" type="button" aria-label="Scroll to top">
+    <i class="fa-solid fa-arrow-up"></i>
+  </button>
+
+  <script src="theme.js"></script>
+  <script>
+    function bindThemeToggle() {
+      const button = document.getElementById('themeToggle');
+      if (!button || button.dataset.bound === 'true') {
+        return;
       }
-    });
 
-    // Smooth scroll to top on click
-    btn.addEventListener("click", function () {
-      window.scrollTo({
-        top: 0,
-        behavior: "smooth"
+      button.dataset.bound = 'true';
+      button.addEventListener('click', () => {
+        const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
+        const nextTheme = currentTheme === 'light' ? 'dark' : 'light';
+        if (window.themeManager) {
+          window.themeManager.setTheme(nextTheme);
+        } else {
+          document.documentElement.setAttribute('data-theme', nextTheme);
+          localStorage.setItem('theme', nextTheme);
+        }
       });
-    });
-  })();
-</script>
-<!-- ===== End Back To Top Button ===== -->
-
-<!-- Scroll-to-Top JS -->
-<script>
-const scrollBtn = document.getElementById("scrollTopBtn");
-
-window.addEventListener("scroll", () => {
-    if (window.scrollY > 300) {
-        scrollBtn.style.display = "block";
-    } else {
-        scrollBtn.style.display = "none";
     }
-});
 
-scrollBtn.addEventListener("click", () => {
-    window.scrollTo({
-        top: 0,
-        behavior: "smooth"
+    function includeHTML() {
+      const nodes = document.querySelectorAll('[w3-include-html]');
+      nodes.forEach(async (node) => {
+        const file = node.getAttribute('w3-include-html');
+        try {
+          const response = await fetch(file);
+          node.innerHTML = response.ok ? await response.text() : 'Page not found.';
+        } catch (error) {
+          node.innerHTML = 'Page not found.';
+        }
+        node.removeAttribute('w3-include-html');
+        bindThemeToggle();
+      });
+    }
+
+    function filterJobs() {
+      const query = document.getElementById('jobSearch').value.trim().toLowerCase();
+      const department = document.getElementById('jobFilter').value;
+
+      document.querySelectorAll('.job-card').forEach((card) => {
+        const title = (card.dataset.title || '').toLowerCase();
+        const dept = card.dataset.department || '';
+        const matchesQuery = !query || title.includes(query) || card.textContent.toLowerCase().includes(query);
+        const matchesDepartment = department === 'all' || dept === department;
+        card.hidden = !(matchesQuery && matchesDepartment);
+      });
+    }
+
+    function setupScrollTop() {
+      const button = document.getElementById('scrollTopBtn');
+      const toggle = () => {
+        button.classList.toggle('is-visible', window.scrollY > 300);
+      };
+
+      window.addEventListener('scroll', toggle, { passive: true });
+      button.addEventListener('click', () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      });
+      toggle();
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      includeHTML();
+      setupScrollTop();
+      document.getElementById('current-year').textContent = new Date().getFullYear();
+      document.getElementById('jobSearch').addEventListener('input', filterJobs);
+      document.getElementById('jobFilter').addEventListener('change', filterJobs);
+      bindThemeToggle();
     });
-});
-</script>
-
-
+  </script>
 </body>
 </html>

--- a/navbar.html
+++ b/navbar.html
@@ -20,15 +20,22 @@
   }
 
   .agritech-navbar {
-    position: sticky;
+    position: fixed;
     top: 0;
     z-index: 1000;
     width: 100%;
     background: var(--navbar-bg);
     color: var(--navbar-text);
+    -webkit-backdrop-filter: blur(14px);
     backdrop-filter: blur(14px);
     border-bottom: 1px solid var(--navbar-border);
     box-shadow: 0 10px 28px var(--navbar-shadow);
+  }
+
+  .agritech-navbar-spacer {
+    height: 76px;
+    width: 100%;
+    flex: 0 0 auto;
   }
 
   .agritech-navbar .navbar-content {
@@ -243,3 +250,4 @@
     </div>
   </div>
 </nav>
+<div class="agritech-navbar-spacer" aria-hidden="true"></div>


### PR DESCRIPTION
Made the shared navbar fixed site-wide by updating navbar.html so every page that includes it now gets the same pinned header, plus a spacer to keep the main content from jumping under it. The shared navbar still preserves the existing theme-toggle state behavior through theme.js.

I also fixed the Safari blur fallback in the navbar. One editor warning remains only because navbar.html is a fragment include rather than a full HTML document, so the doctype check is not applicable there.

closes #1644