### PR TITLE
Show Loading Spinner While Prediction is Running

### DIFF
--- a/ai_disease.html
+++ b/ai_disease.html
@@ -282,10 +282,10 @@
             </button>
         </div>
 
-        <div class="card hidden" id="loadingCard">
+        <div class="card hidden" id="loadingCard" role="status" aria-live="polite">
             <div class="loading">
                 <div class="spinner"></div>
-                <p>Analyzing image with AI...</p>
+                <p>Predicting... Please wait</p>
             </div>
         </div>
 

--- a/ai_disease.js
+++ b/ai_disease.js
@@ -1,6 +1,33 @@
 const API_BASE = '/api/v1/ai-disease';
 
 let selectedImage = null;
+let analyzeButtonOriginalHtml = null;
+
+function setPredictionLoadingState(isLoading) {
+    const loadingCard = document.getElementById('loadingCard');
+    const analyzeBtn = document.getElementById('analyzeBtn');
+
+    if (loadingCard) {
+        loadingCard.classList.toggle('hidden', !isLoading);
+    }
+
+    if (!analyzeBtn) return;
+
+    if (isLoading) {
+        if (analyzeButtonOriginalHtml === null) {
+            analyzeButtonOriginalHtml = analyzeBtn.innerHTML;
+        }
+        analyzeBtn.disabled = true;
+        analyzeBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Predicting...';
+    } else {
+        analyzeBtn.disabled = false;
+
+        if (analyzeButtonOriginalHtml !== null) {
+            analyzeBtn.innerHTML = analyzeButtonOriginalHtml;
+            analyzeButtonOriginalHtml = null;
+        }
+    }
+}
 
 function setStatusMessage(message, type = 'info') {
     const existing = document.getElementById('statusMessage');
@@ -62,9 +89,8 @@ async function analyzeImage() {
         return;
     }
 
-    document.getElementById('loadingCard').classList.remove('hidden');
+    setPredictionLoadingState(true);
     document.getElementById('resultCard').classList.add('hidden');
-    document.getElementById('analyzeBtn').disabled = true;
 
     try {
         const imageBase64 = selectedImage.split(',')[1];
@@ -112,10 +138,7 @@ async function analyzeImage() {
         );
 
     } finally {
-
-        document.getElementById('loadingCard').classList.add('hidden');
-
-        document.getElementById('analyzeBtn').disabled = false;
+        setPredictionLoadingState(false);
     }
 }
 


### PR DESCRIPTION
Implemented the request on the disease prediction flow. The request lifecycle now toggles a shared loading state so the spinner appears, the button is disabled during the API call, and both are restored in the success or error path. The loader copy now reads “Predicting... Please wait” in ai_disease.html, and the button/loading wiring lives in ai_disease.js.

Validation passed for the touched files with no syntax errors.


closes #1052