### PR TITLE
Bug :disease.js & disease.html – Race Condition in Image Upload

### DIFF
--- a/disease.js
+++ b/disease.js
@@ -255,6 +255,8 @@ const loading = document.getElementById("loading");
 const resultsDiv = document.getElementById("results");
 
 let selectedFile = null;
+let uploadInProgress = false;
+let fileSelectionToken = 0;
 
 // File upload handling
 uploadArea.addEventListener("click", () => fileInput.click());
@@ -308,7 +310,7 @@ fileInput.addEventListener("change", (e) => {
 
 // Analysis function
 analyzeBtn.addEventListener("click", async () => {
-  if (!selectedFile) return;
+  if (uploadInProgress || !selectedFile) return;
 
   loading.style.display = "block";
   resultsDiv.innerHTML = "";
@@ -470,40 +472,59 @@ function validateImage(file) {
   return true;
 }
 
+function readPreviewDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = (event) => resolve(event.target.result);
+    reader.onerror = () => reject(new Error("Error loading image preview."));
+    reader.readAsDataURL(file);
+  });
+}
+
 // Enhanced file handling with validation
-function handleFileSelect(file) {
+async function handleFileSelect(file) {
+  const currentSelectionToken = ++fileSelectionToken;
+
   try {
     validateImage(file);
-    selectedFile = file;
+    uploadInProgress = true;
+    selectedFile = null;
+    analyzeBtn.disabled = true;
 
     previewContainer.innerHTML = '<div class="spinner"></div>';
 
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      previewContainer.innerHTML = `<img src="${e.target.result}" alt="Plant preview" class="preview-image">`;
-      analyzeBtn.disabled = false;
-      resultsDiv.innerHTML = "";
-      document.getElementById("downloadPdfBtn").style.display = "none";
+    const previewDataUrl = await readPreviewDataUrl(file);
 
-      document.getElementById("modelStatus").innerHTML =
-        "🔍 Image loaded - Ready for analysis";
-      document.getElementById("modelStatus").className =
-        "status-indicator status-warning";
-    };
+    if (currentSelectionToken !== fileSelectionToken) {
+      return;
+    }
 
-    reader.onerror = () => {
-      previewContainer.innerHTML =
-        '<div class="no-results">❌ Error loading image</div>';
-      selectedFile = null;
-    };
+    selectedFile = file;
+    previewContainer.innerHTML = `<img src="${previewDataUrl}" alt="Plant preview" class="preview-image">`;
+    resultsDiv.innerHTML = "";
+    document.getElementById("downloadPdfBtn").style.display = "none";
 
-    reader.readAsDataURL(file);
+    document.getElementById("modelStatus").innerHTML =
+      "🔍 Image loaded - Ready for analysis";
+    document.getElementById("modelStatus").className =
+      "status-indicator status-warning";
+
+    analyzeBtn.disabled = false;
   } catch (error) {
+    if (currentSelectionToken !== fileSelectionToken) {
+      return;
+    }
+
     alert(error.message);
     previewContainer.innerHTML =
       '<div class="no-results">📷 Upload an image to get started</div>';
     selectedFile = null;
     analyzeBtn.disabled = true;
+  } finally {
+    if (currentSelectionToken === fileSelectionToken) {
+      uploadInProgress = false;
+    }
   }
 }
 


### PR DESCRIPTION
The race is fixed in disease.js. File selection is now promise-based, the Analyze button is disabled immediately while the preview is loading, stale callbacks are ignored with a selection token, and the selected file is only committed after the latest load finishes. The analyze path also refuses to run while an upload is still pending at disease.js.

The button was already disabled in the markup at disease.html, so no HTML change was needed. I validated the edited JS with get_errors and it returned no errors.

closes #145