### PR TITLE
Add lamp indicator toggle for login and signup forms

### DIFF
--- a/login.css
+++ b/login.css
@@ -644,3 +644,32 @@ input::-webkit-reveal {
     margin-bottom: 15px;
   }
 }
+/* Lamp Toggle */
+.lamp-container {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+#lampToggle {
+  padding: 10px 18px;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  background: #ffd54f;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+/* Dark Overlay */
+#darkOverlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 20px;
+  z-index: 5;
+  transition: opacity 0.4s ease;
+}
+
+.hidden {
+  display: none;
+}

--- a/login.html
+++ b/login.html
@@ -50,7 +50,11 @@
           </svg>
         </button>
       </div>
+      <div class="lamp-container">
+        <button id="lampToggle" type="button">💡 ON</button>
+    </div>
 
+      <div id="darkOverlay" class="hidden"></div>
       <!-- Brand section -->
       <div class="brand-section">
         <a href="./index.html" class="brand-icon">

--- a/login.js
+++ b/login.js
@@ -108,3 +108,37 @@ function togglePassword() {
     eyeIcon.className  = "fas fa-eye";
   }
 }
+// Lamp Toggle Feature
+document.addEventListener("DOMContentLoaded", () => {
+  const lampToggle = document.getElementById("lampToggle");
+  const darkOverlay = document.getElementById("darkOverlay");
+
+  if (!lampToggle || !darkOverlay) return;
+
+  const inputs = document.querySelectorAll(
+    'input, button[type="submit"]'
+  );
+
+  let lampOn = true;
+
+  lampToggle.addEventListener("click", () => {
+    lampOn = !lampOn;
+
+    if (lampOn) {
+      lampToggle.textContent = "💡 ON";
+      darkOverlay.classList.add("hidden");
+
+      inputs.forEach(input => {
+        input.disabled = false;
+      });
+
+    } else {
+      lampToggle.textContent = "💡 OFF";
+      darkOverlay.classList.remove("hidden");
+
+      inputs.forEach(input => {
+        input.disabled = true;
+      });
+    }
+  });
+});

--- a/register.css
+++ b/register.css
@@ -547,3 +547,32 @@ input::-webkit-reveal {
 .form-container a:hover {
   color: #0f3d1e;
 }
+/* Lamp Toggle */
+.lamp-container {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+#lampToggle {
+  padding: 10px 18px;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  background: #ffd54f;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+/* Dark Overlay */
+#darkOverlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 20px;
+  z-index: 5;
+  transition: opacity 0.4s ease;
+}
+
+.hidden {
+  display: none;
+}

--- a/register.js
+++ b/register.js
@@ -262,3 +262,37 @@ document.addEventListener("keydown", function (e) {
 
 document.addEventListener("DOMContentLoaded", updateProgress);
 document.getElementById("password").addEventListener("input", checkPasswordStrength);
+// Lamp Toggle Feature
+document.addEventListener("DOMContentLoaded", () => {
+  const lampToggle = document.getElementById("lampToggle");
+  const darkOverlay = document.getElementById("darkOverlay");
+
+  if (!lampToggle || !darkOverlay) return;
+
+  const formInputs = document.querySelectorAll(
+    "#role, #fullname, #email, #password, #confirmPassword, #register-btn"
+  );
+
+  let lampOn = true;
+
+  lampToggle.addEventListener("click", () => {
+    lampOn = !lampOn;
+
+    if (lampOn) {
+      lampToggle.textContent = "💡 ON";
+      darkOverlay.classList.add("hidden");
+
+      formInputs.forEach(input => {
+        input.disabled = false;
+      });
+
+    } else {
+      lampToggle.textContent = "💡 OFF";
+      darkOverlay.classList.remove("hidden");
+
+      formInputs.forEach(input => {
+        input.disabled = true;
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Which issue does this PR close?

Closes #1692

## Rationale for this change

This feature adds an interactive lamp indicator to the login and registration pages, allowing users to visually control whether forms are active or inactive.

## What changes are included in this PR?

* Added a lamp toggle button (ON/OFF)
* Added a dark overlay when the lamp is OFF
* Disabled login form inputs when the lamp is OFF
* Disabled registration form inputs when the lamp is OFF
* Re-enabled inputs when the lamp is ON
* Added smooth visual interaction for improved user experience

## Are these changes tested?

Yes.

* Tested login page lamp toggle functionality
* Tested registration page lamp toggle functionality
* Verified form fields are disabled when lamp is OFF
* Verified form fields are enabled when lamp is ON

## Are there any user-facing changes?

Yes. Users can now use the lamp indicator to toggle form interactivity on login and registration pages.
